### PR TITLE
Install bun in agentic workflow runners

### DIFF
--- a/.github/workflows/daily-perf-improver.lock.yml
+++ b/.github/workflows/daily-perf-improver.lock.yml
@@ -31,7 +31,7 @@
 # - Updates a monthly activity summary for maintainer visibility
 # Always methodical, measurement-driven, and mindful of trade-offs.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f58dc7fff9efda63dcd44f4b2b32fbf204836c16d61097a6cbb65ae36f4c81c0","compiler_version":"v0.56.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"cfb27351be08b6adabd11902e5d2b6c69184e4d71f8c56850174b840daab7c1c","compiler_version":"v0.56.1","strict":true}
 
 name: "Daily Perf Improver"
 "on":
@@ -371,8 +371,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          bun-version: '1.1'
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - name: Install bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       # Repo memory git-based storage configuration from frontmatter processed below
       - name: Clone repo-memory branch (default)
         env:

--- a/.github/workflows/daily-perf-improver.md
+++ b/.github/workflows/daily-perf-improver.md
@@ -61,6 +61,14 @@ tools:
   repo-memory: true
 engine: claude
 
+steps:
+  - name: Install bun
+    run: |
+      curl -fsSL https://bun.sh/install | bash
+      echo "$HOME/.bun/bin" >> $GITHUB_PATH
+  - name: Install dependencies
+    run: bun install --frozen-lockfile
+
 ---
 
 # Daily Perf Improver

--- a/.github/workflows/daily-test-improver.lock.yml
+++ b/.github/workflows/daily-test-improver.lock.yml
@@ -31,7 +31,7 @@
 # - Updates a monthly activity summary for maintainer visibility
 # Always thoughtful, quality-focused, and mindful of test maintainability.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"238660994a2b5e2ff516db7bfcf8e8ccf0d19a2a39b1f53d4ba1a4e42a962dab","compiler_version":"v0.56.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a2b451713d8719174de47c7414a29f463278f190448c4eb00dcc4788b400135c","compiler_version":"v0.56.1","strict":true}
 
 name: "Daily Test Improver"
 "on":
@@ -371,8 +371,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          bun-version: '1.1'
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - name: Install bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       # Repo memory git-based storage configuration from frontmatter processed below
       - name: Clone repo-memory branch (default)
         env:

--- a/.github/workflows/daily-test-improver.md
+++ b/.github/workflows/daily-test-improver.md
@@ -61,6 +61,14 @@ tools:
   repo-memory: true
 engine: claude
 
+steps:
+  - name: Install bun
+    run: |
+      curl -fsSL https://bun.sh/install | bash
+      echo "$HOME/.bun/bin" >> $GITHUB_PATH
+  - name: Install dependencies
+    run: bun install --frozen-lockfile
+
 ---
 
 # Daily Test Improver

--- a/.github/workflows/glossary-maintainer.lock.yml
+++ b/.github/workflows/glossary-maintainer.lock.yml
@@ -23,7 +23,7 @@
 #
 # Maintains and updates the documentation glossary based on codebase changes
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"09ebfe66f43b048dcc50dddab9f96d601012997bd6a7a43c8e5651021be7b687","compiler_version":"v0.56.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"cd6fcbacee301bfc286ca92bafef84a68307537f687038ecccdcd84c1efebcb4","compiler_version":"v0.56.1","strict":true}
 
 name: "Glossary Maintainer"
 "on":
@@ -272,8 +272,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          bun-version: '1.1'
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - name: Install bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       # Cache memory file share configuration from frontmatter processed below
       - name: Create cache-memory directory
         run: bash /opt/gh-aw/actions/create_cache_memory_dir.sh

--- a/.github/workflows/glossary-maintainer.md
+++ b/.github/workflows/glossary-maintainer.md
@@ -35,6 +35,14 @@ tools:
 timeout-minutes: 20
 engine: claude
 
+steps:
+  - name: Install bun
+    run: |
+      curl -fsSL https://bun.sh/install | bash
+      echo "$HOME/.bun/bin" >> $GITHUB_PATH
+  - name: Install dependencies
+    run: bun install --frozen-lockfile
+
 ---
 
 # Glossary Maintainer

--- a/.github/workflows/pr-fix.lock.yml
+++ b/.github/workflows/pr-fix.lock.yml
@@ -27,7 +27,7 @@
 # comments explaining changes made. Helps rapidly resolve PR blockers and keep
 # development flowing.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a69ca2f9ff7d702df740bfc065126ddd938c98a250652226b226369bcfcfb9d2","compiler_version":"v0.56.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"895bca6e2165538d4f00f0befcfda6723c80441207ae5a82950f2ab74bcaf06e","compiler_version":"v0.56.1","strict":true}
 
 name: "PR Fix"
 "on":
@@ -343,8 +343,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          bun-version: '1.1'
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - name: Install bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}

--- a/.github/workflows/pr-fix.md
+++ b/.github/workflows/pr-fix.md
@@ -29,6 +29,14 @@ tools:
 timeout-minutes: 20
 engine: claude
 
+steps:
+  - name: Install bun
+    run: |
+      curl -fsSL https://bun.sh/install | bash
+      echo "$HOME/.bun/bin" >> $GITHUB_PATH
+  - name: Install dependencies
+    run: bun install --frozen-lockfile
+
 ---
 
 # PR Fix

--- a/.github/workflows/repo-assist.lock.yml
+++ b/.github/workflows/repo-assist.lock.yml
@@ -34,7 +34,7 @@
 # - Maintains a persistent memory of work done and what remains
 # Always polite, constructive, and mindful of the project's goals.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ad8413d7a8214ca21ccb0892f230f6c46d59b6649d10048da844d7fccdef6c9d","compiler_version":"v0.56.1","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"66d7ee202ad5942ac1608a6ecf959962f3392024e06f2dcba267d65d6742cb18","compiler_version":"v0.56.1","strict":true}
 
 name: "Repo Assist"
 "on":
@@ -374,8 +374,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          bun-version: '1.1'
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - name: Install bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
       - env:
           GH_TOKEN: ${{ github.token }}
         name: Fetch repo data for task weighting

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -72,6 +72,12 @@ tools:
   repo-memory: true
 
 steps:
+  - name: Install bun
+    run: |
+      curl -fsSL https://bun.sh/install | bash
+      echo "$HOME/.bun/bin" >> $GITHUB_PATH
+  - name: Install dependencies
+    run: bun install --frozen-lockfile
   - name: Fetch repo data for task weighting
     env:
       GH_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Agents
+
+Instructions for AI agents working on this repository.
+
+## Setup
+
+This project uses **Bun** as its runtime and package manager. Bun is installed
+via the workflow setup step, but if you need to install it manually:
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+export PATH="$HOME/.bun/bin:$PATH"
+bun install --frozen-lockfile
+```
+
+## Commands
+
+```bash
+bun test              # Run all tests (must pass before creating PRs)
+bun test --watch      # Watch mode
+bun run bench         # Run benchmarks
+bun run typecheck     # TypeScript type checking (must pass)
+bun run lint          # Biome + GritQL lint (must pass)
+bun run build:demo    # Build demo (generates sources.gen.ts)
+```
+
+**All three checks must pass before creating a PR**: `bun test`, `bun run typecheck`, `bun run lint`.
+
+## Code Style
+
+- **No `any`, `unknown`, or `as` type assertions** — banned by Biome. When unavoidable, add a `biome-ignore` comment with an `expect:` explanation:
+  ```ts
+  // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction requires cast
+  ```
+- **No new dependencies** without discussion in an issue first.
+- Match existing formatting and naming conventions.
+- Prefer small, focused changes — one concern per PR.
+
+## Architecture
+
+- `src/multibuffer/` — Data model (rendering-agnostic): buffer, excerpt, multibuffer, anchor, selection
+- `src/multibuffer_renderer/` — Rendering abstraction: DOM renderer, measurement, viewport, highlighting
+- `src/editor/` — Editor commands: cursor movement, text editing, input handling, undo/redo
+- `demo/` — Demo harness with fixture scenarios
+- `tests/` — Test suite (~590 tests)
+- `benchmarks/` — Performance benchmarks
+
+## Performance
+
+Targets: <1ms keypress-to-model, <1ms viewport calculation, 100+ excerpts.
+Always measure before/after when proposing performance changes.
+
+## Approach
+
+Types → Tests → Benchmarks → Implementation (TDD).
+Write tests before implementation code.

--- a/tests/renderer/wrap-map.test.ts
+++ b/tests/renderer/wrap-map.test.ts
@@ -14,10 +14,10 @@ import { createBuffer } from "../../src/multibuffer/buffer.ts";
 import { createMultiBuffer } from "../../src/multibuffer/multibuffer.ts";
 import type { MultiBufferRow } from "../../src/multibuffer/types.ts";
 import {
-  WrapMap,
   charColToVisualCol,
   visualColToCharCol,
   visualWidth,
+  WrapMap,
   wrapLine,
 } from "../../src/multibuffer_renderer/wrap-map.ts";
 import { createBufferId, excerptRange, num, resetCounters } from "../helpers.ts";


### PR DESCRIPTION
## Summary

- Adds `steps:` to install bun + `bun install` before agent runs for all workflows with bash access (repo-assist, daily-perf-improver, daily-test-improver, pr-fix, glossary-maintainer)
- Creates `AGENTS.md` with setup commands, code style rules, and architecture overview so agents know how to work with this repo
- Fixes upstream lint issue in wrap-map.test.ts (import ordering)

## Test plan

- [x] `gh aw compile` — 0 errors, 0 warnings
- [x] `bun run lint` — clean
- [ ] Verify next workflow run can execute `bun test`