### PR TITLE
feat(editor): add indent/dedent and auto-indent

### DIFF
--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -295,7 +295,18 @@ export class Editor {
         this._insertText(snap, "\n");
         break;
       case "insertTab":
-        this._insertText(snap, "  ");
+        // If there's a non-collapsed selection, indent the selected lines
+        if (this._selection && !isCollapsed(snap, this._selection)) {
+          this._indentLines(snap);
+        } else {
+          this._insertText(snap, "  ");
+        }
+        break;
+      case "indentLines":
+        this._indentLines(snap);
+        break;
+      case "dedentLines":
+        this._dedentLines(snap);
         break;
       case "deleteBackward":
         this._deleteBackward(snap, command.granularity);
@@ -361,13 +372,26 @@ export class Editor {
 
   private _insertText(snap: MultiBufferSnapshot, text: string): void {
     this._goalColumn = undefined;
+
+    // Auto-indent: when inserting a newline, match the current line's indentation
+    let insertText = text;
+    if (text === "\n") {
+      const cursor = this.cursor;
+      // biome-ignore lint/plugin/no-type-assertion: expect: branded arithmetic for row range
+      const lineText = snap.lines(cursor.row, (cursor.row + 1) as MultiBufferRow)[0] ?? "";
+      const match = lineText.match(/^( +)/);
+      if (match?.[1]) {
+        insertText = `\n${match[1]}`;
+      }
+    }
+
     if (this._selection && !isCollapsed(snap, this._selection)) {
       // Replace selection with text
       const range = resolveAnchorRange(snap, this._selection.range);
       if (range) {
-        this._edit(snap, range.start, range.end, text);
+        this._edit(snap, range.start, range.end, insertText);
         const newSnap = this.multiBuffer.snapshot();
-        const newCursor = this._advancePoint(range.start, text, newSnap);
+        const newCursor = this._advancePoint(range.start, insertText, newSnap);
         this._cursor = newCursor;
         this._selection = selectionAtPoint(this.multiBuffer, newCursor);
         return;
@@ -376,9 +400,9 @@ export class Editor {
 
     // Insert at cursor
     const cursor = this.cursor;
-    this._edit(snap, cursor, cursor, text);
+    this._edit(snap, cursor, cursor, insertText);
     const newSnap = this.multiBuffer.snapshot();
-    const newCursor = this._advancePoint(cursor, text, newSnap);
+    const newCursor = this._advancePoint(cursor, insertText, newSnap);
     this._cursor = newCursor;
     this._selection = selectionAtPoint(this.multiBuffer, newCursor);
   }
@@ -608,7 +632,7 @@ export class Editor {
     this._selection = selectionAtPoint(this.multiBuffer, newCursor);
   }
 
-  private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
+private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
     this._goalColumn = undefined;
     const cursor = this.cursor;
     const row = cursor.row;
@@ -709,6 +733,103 @@ export class Editor {
     const newCursor: MultiBufferPoint = { row, column: 0 };
     this._cursor = newCursor;
     this._selection = selectionAtPoint(this.multiBuffer, newCursor);
+  }
+
+  /**
+   * Indent all lines touched by the current selection (or just the cursor line)
+   * by prepending 2 spaces to each. Uses a single _edit() for atomic undo.
+   */
+  private _indentLines(snap: MultiBufferSnapshot): void {
+    this._goalColumn = undefined;
+    const { startRow, endRow } = this._affectedRows(snap);
+
+    // biome-ignore lint/plugin/no-type-assertion: expect: branded arithmetic for row range
+    const lines = snap.lines(startRow, (endRow + 1) as MultiBufferRow);
+    const indented = lines.map((line) => `  ${line}`);
+
+    const rangeStart: MultiBufferPoint = { row: startRow, column: 0 };
+    const lastLineLen = lines[lines.length - 1]?.length ?? 0;
+    const rangeEnd: MultiBufferPoint = { row: endRow, column: lastLineLen };
+
+    this._edit(snap, rangeStart, rangeEnd, indented.join("\n"));
+
+    // Place cursor at its shifted position
+    const cursor = this.cursor;
+    const newCursor: MultiBufferPoint = { row: cursor.row, column: cursor.column + 2 };
+    const newSnap = this.multiBuffer.snapshot();
+    this._cursor = newSnap.clipPoint(newCursor, Bias.Left);
+    this._selection = selectionAtPoint(this.multiBuffer, this._cursor);
+  }
+
+  /**
+   * Dedent all lines touched by the current selection (or just the cursor line)
+   * by removing up to 2 leading spaces from each. Uses a single _edit() for atomic undo.
+   */
+  private _dedentLines(snap: MultiBufferSnapshot): void {
+    this._goalColumn = undefined;
+    const { startRow, endRow } = this._affectedRows(snap);
+
+    // biome-ignore lint/plugin/no-type-assertion: expect: branded arithmetic for row range
+    const lines = snap.lines(startRow, (endRow + 1) as MultiBufferRow);
+
+    // Check if any line actually has leading spaces to remove
+    let anyChange = false;
+    const dedented = lines.map((line) => {
+      let spacesToRemove = 0;
+      if (line.length > 0 && line[0] === " ") {
+        spacesToRemove = 1;
+        if (line.length > 1 && line[1] === " ") {
+          spacesToRemove = 2;
+        }
+      }
+      if (spacesToRemove > 0) anyChange = true;
+      return line.slice(spacesToRemove);
+    });
+
+    if (!anyChange) return;
+
+    const rangeStart: MultiBufferPoint = { row: startRow, column: 0 };
+    const lastLineLen = lines[lines.length - 1]?.length ?? 0;
+    const rangeEnd: MultiBufferPoint = { row: endRow, column: lastLineLen };
+
+    // Figure out how many spaces were removed from the cursor's line
+    const cursor = this.cursor;
+    const cursorLineIndex = cursor.row - startRow;
+    const cursorLine = lines[cursorLineIndex] ?? "";
+    let spacesRemovedOnCursorLine = 0;
+    if (cursorLine.length > 0 && cursorLine[0] === " ") {
+      spacesRemovedOnCursorLine = 1;
+      if (cursorLine.length > 1 && cursorLine[1] === " ") {
+        spacesRemovedOnCursorLine = 2;
+      }
+    }
+
+    this._edit(snap, rangeStart, rangeEnd, dedented.join("\n"));
+
+    // Adjust cursor column
+    const newCol = Math.max(0, cursor.column - spacesRemovedOnCursorLine);
+    const newCursor: MultiBufferPoint = { row: cursor.row, column: newCol };
+    const newSnap = this.multiBuffer.snapshot();
+    this._cursor = newSnap.clipPoint(newCursor, Bias.Left);
+    this._selection = selectionAtPoint(this.multiBuffer, this._cursor);
+  }
+
+  /**
+   * Determine the range of rows affected by the current selection or cursor.
+   * Returns inclusive start and end rows.
+   */
+  private _affectedRows(snap: MultiBufferSnapshot): {
+    startRow: MultiBufferRow;
+    endRow: MultiBufferRow;
+  } {
+    if (this._selection && !isCollapsed(snap, this._selection)) {
+      const range = resolveAnchorRange(snap, this._selection.range);
+      if (range) {
+        return { startRow: range.start.row, endRow: range.end.row };
+      }
+    }
+    const cursor = this.cursor;
+    return { startRow: cursor.row, endRow: cursor.row };
   }
 
   private _cut(snap: MultiBufferSnapshot): void {

--- a/src/editor/input-handler.ts
+++ b/src/editor/input-handler.ts
@@ -209,6 +209,7 @@ export function keyEventToCommand(e: KeyboardEvent): EditorCommand | undefined {
       return { type: "insertNewline" };
 
     case "Tab":
+      if (shift) return { type: "dedentLines" };
       return { type: "insertTab" };
 
     // ── Shortcuts ───────────────────────────────────────────────
@@ -236,6 +237,14 @@ export function keyEventToCommand(e: KeyboardEvent): EditorCommand | undefined {
 
     case "v":
       // Paste is handled via the paste event, not keydown
+      return undefined;
+
+    case "]":
+      if (mod) return { type: "indentLines" };
+      return undefined;
+
+    case "[":
+      if (mod) return { type: "dedentLines" };
       return undefined;
 
     default:

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -36,6 +36,8 @@ export type EditorCommand =
   | { type: "duplicateLine"; direction: "up" | "down" }
   | { type: "insertLineBelow" }
   | { type: "insertLineAbove" }
+  | { type: "indentLines" }
+  | { type: "dedentLines" }
   | { type: "undo" }
   | { type: "redo" }
   | { type: "copy" }

--- a/tests/editor/editor.test.ts
+++ b/tests/editor/editor.test.ts
@@ -1199,6 +1199,23 @@ describe("keyEventToCommand", () => {
     const cmd = keyEventToCommand(key("PageDown", { shift: true }));
     expect(cmd).toEqual({ type: "extendSelection", direction: "down", granularity: "page" });
   });
+
+  // ── Indentation bindings ──────────────────────────────────────
+
+  test("Shift+Tab → dedentLines", () => {
+    const cmd = keyEventToCommand(key("Tab", { shift: true }));
+    expect(cmd).toEqual({ type: "dedentLines" });
+  });
+
+  test("Mod+] → indentLines", () => {
+    const cmd = keyEventToCommand(key("]", { mod: true }));
+    expect(cmd).toEqual({ type: "indentLines" });
+  });
+
+  test("Mod+[ → dedentLines", () => {
+    const cmd = keyEventToCommand(key("[", { mod: true }));
+    expect(cmd).toEqual({ type: "dedentLines" });
+  });
 });
 
 // ─── Goal Column ──────────────────────────────────────────────────
@@ -1694,5 +1711,98 @@ describe("Editor - Line Operations", () => {
     expect(getText(mb)).toBe("AAA\n\nBBB");
     editor.dispatch({ type: "undo" });
     expect(getText(mb)).toBe("AAA\nBBB");
+  });
+});
+
+// ─── Indentation ─────────────────────────────────────────────────
+
+describe("Editor - Indentation", () => {
+  test("indent single line (no selection)", () => {
+    const { mb, editor } = setup("hello\nworld");
+    editor.setCursor(mbPoint(0, 2));
+    editor.dispatch({ type: "indentLines" });
+    expect(getText(mb)).toBe("  hello\nworld");
+  });
+
+  test("indent multiple selected lines", () => {
+    const { mb, editor } = setup("aaa\nbbb\nccc");
+    selectRange(editor, 0, 1, 2, 1);
+    editor.dispatch({ type: "indentLines" });
+    expect(getText(mb)).toBe("  aaa\n  bbb\n  ccc");
+  });
+
+  test("dedent single line", () => {
+    const { mb, editor } = setup("  hello\nworld");
+    editor.setCursor(mbPoint(0, 4));
+    editor.dispatch({ type: "dedentLines" });
+    expect(getText(mb)).toBe("hello\nworld");
+  });
+
+  test("dedent line with less than 2 spaces (removes what's there)", () => {
+    const { mb, editor } = setup(" hello\nworld");
+    editor.setCursor(mbPoint(0, 3));
+    editor.dispatch({ type: "dedentLines" });
+    expect(getText(mb)).toBe("hello\nworld");
+  });
+
+  test("dedent line with no indentation (no-op)", () => {
+    const { mb, editor } = setup("hello\nworld");
+    editor.setCursor(mbPoint(0, 2));
+    editor.dispatch({ type: "dedentLines" });
+    expect(getText(mb)).toBe("hello\nworld");
+  });
+
+  test("indent preserves cursor position", () => {
+    const { editor } = setup("hello");
+    editor.setCursor(mbPoint(0, 3));
+    editor.dispatch({ type: "indentLines" });
+    // Cursor should shift right by the indent amount
+    expectPoint(editor.cursor, 0, 5);
+  });
+
+  test("auto-indent on Enter matches previous line's indentation", () => {
+    const { mb, editor } = setup("  hello");
+    editor.setCursor(mbPoint(0, 7));
+    editor.dispatch({ type: "insertNewline" });
+    expect(getText(mb)).toBe("  hello\n  ");
+  });
+
+  test("auto-indent on Enter from unindented line (no extra spaces)", () => {
+    const { mb, editor } = setup("hello");
+    editor.setCursor(mbPoint(0, 5));
+    editor.dispatch({ type: "insertNewline" });
+    expect(getText(mb)).toBe("hello\n");
+  });
+
+  test("undo indent restores original indentation", () => {
+    const { mb, editor } = setup("hello\nworld");
+    editor.setCursor(mbPoint(0, 2));
+    editor.dispatch({ type: "indentLines" });
+    expect(getText(mb)).toBe("  hello\nworld");
+    editor.dispatch({ type: "undo" });
+    expect(getText(mb)).toBe("hello\nworld");
+  });
+
+  test("undo auto-indent", () => {
+    const { mb, editor } = setup("  hello");
+    editor.setCursor(mbPoint(0, 7));
+    editor.dispatch({ type: "insertNewline" });
+    expect(getText(mb)).toBe("  hello\n  ");
+    editor.dispatch({ type: "undo" });
+    expect(getText(mb)).toBe("  hello");
+  });
+
+  test("insertTab with non-collapsed selection indents lines", () => {
+    const { mb, editor } = setup("aaa\nbbb\nccc");
+    selectRange(editor, 0, 1, 2, 1);
+    editor.dispatch({ type: "insertTab" });
+    expect(getText(mb)).toBe("  aaa\n  bbb\n  ccc");
+  });
+
+  test("dedent multiple selected lines", () => {
+    const { mb, editor } = setup("  aaa\n  bbb\n  ccc");
+    selectRange(editor, 0, 3, 2, 3);
+    editor.dispatch({ type: "dedentLines" });
+    expect(getText(mb)).toBe("aaa\nbbb\nccc");
   });
 });


### PR DESCRIPTION
## Summary
- **indentLines**: Prepends 2 spaces to affected lines (cursor line or selection)
- **dedentLines**: Removes up to 2 leading spaces from affected lines
- **Auto-indent on Enter**: New lines match the indentation of the current line
- `Tab` with a non-collapsed selection now indents all selected lines
- Keybindings: `Shift+Tab`, `Mod+]`, `Mod+[`

Closes #mm3lh125 (Indentation)

## Test plan
- [x] 15 new tests pass (12 editor + 3 keybinding tests)
- [ ] Manual test: Tab with selection indents lines
- [ ] Manual test: Shift+Tab dedents
- [ ] Manual test: Enter preserves indentation
- [ ] Manual test: Undo/redo works