### PR TITLE
fix: typecheck without build + bump biome schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
 	"files": {
 		"includes": ["src/**", "tests/**", "benchmarks/**", "demo/demo.ts", "demo/serve.ts", "demo/build.ts", "demo/fixtures/**"]
 	},

--- a/demo/sources.gen.d.ts
+++ b/demo/sources.gen.d.ts
@@ -1,0 +1,3 @@
+// Type declaration for the build-time generated sources file.
+// The actual file is created by `bun run demo/build.ts` and is gitignored.
+export declare const sources: { path: string; content: string }[];


### PR DESCRIPTION
## Summary
- Add `demo/sources.gen.d.ts` type declaration so `bun run typecheck` passes without running `bun run demo/build.ts` first
- Bump `biome.json` schema from 2.4.4 to 2.4.6 to match installed CLI version

## Test plan
- [x] `bun test` — 732 pass, 0 fail
- [x] `bun run typecheck` — clean (with and without `sources.gen.ts`)
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)