### PR TITLE
feat(diff): Myers diff algorithm + unified diff view

### DIFF
--- a/benchmarks/diff.bench.ts
+++ b/benchmarks/diff.bench.ts
@@ -1,0 +1,127 @@
+/**
+ * Diff benchmarks.
+ *
+ * Measures diff algorithm performance across various scenarios:
+ * - Small files with few changes
+ * - Large files with scattered edits
+ * - Complete rewrites (worst case for Myers)
+ * - Unified diff view construction
+ */
+
+import type { BufferId } from "../src/buffer/types.ts";
+import { diff } from "../src/diff/diff.ts";
+import { createUnifiedDiff } from "../src/diff/unified.ts";
+import type { BenchmarkSuite } from "./harness.ts";
+
+// biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in benchmarks
+const oldId = "old.ts" as BufferId;
+// biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in benchmarks
+const newId = "new.ts" as BufferId;
+
+/** Generate a file with numbered lines. */
+function generateLines(count: number): string {
+  return Array.from({ length: count }, (_, i) =>
+    `  const value${i} = compute(${i});`,
+  ).join("\n");
+}
+
+/** Modify every Nth line of a text. */
+function modifyEveryNth(text: string, n: number): string {
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i += n) {
+    lines[i] = `  const modified${i} = updated(${i}); // changed`;
+  }
+  return lines.join("\n");
+}
+
+/** Insert a line after every Nth line. */
+function insertEveryNth(text: string, n: number): string {
+  const lines = text.split("\n");
+  const result: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    result.push(lines[i] ?? "");
+    if (i % n === 0) {
+      result.push(`  // inserted after line ${i}`);
+    }
+  }
+  return result.join("\n");
+}
+
+/** Delete every Nth line. */
+function deleteEveryNth(text: string, n: number): string {
+  return text.split("\n").filter((_, i) => i % n !== 0).join("\n");
+}
+
+// --- Fixtures ---
+
+const small100 = generateLines(100);
+const small100Modified = modifyEveryNth(small100, 20);
+
+const medium1k = generateLines(1_000);
+const medium1kScattered = modifyEveryNth(medium1k, 50);
+const medium1kInserted = insertEveryNth(medium1k, 100);
+const medium1kDeleted = deleteEveryNth(medium1k, 100);
+
+const large10k = generateLines(10_000);
+const large10kFewChanges = modifyEveryNth(large10k, 2000);
+const medium1kRewrite = generateLines(1_000).replace(/compute/g, "calculate");
+
+export const diffBenchmarks: BenchmarkSuite = {
+  name: "Diff",
+  benchmarks: [
+    {
+      name: "diff - 100 lines, 5 changes",
+      fn() {
+        diff(small100, small100Modified);
+      },
+    },
+    {
+      name: "diff - 1K lines, scattered edits",
+      fn() {
+        diff(medium1k, medium1kScattered);
+      },
+    },
+    {
+      name: "diff - 1K lines, insertions",
+      fn() {
+        diff(medium1k, medium1kInserted);
+      },
+    },
+    {
+      name: "diff - 1K lines, deletions",
+      fn() {
+        diff(medium1k, medium1kDeleted);
+      },
+    },
+    {
+      name: "diff - 10K lines, few changes",
+      fn() {
+        diff(large10k, large10kFewChanges);
+      },
+    },
+    {
+      name: "diff - 1K lines, full rewrite (worst case)",
+      fn() {
+        diff(medium1k, medium1kRewrite);
+      },
+    },
+    {
+      name: "diff - identical 1K lines (best case)",
+      fn() {
+        diff(medium1k, medium1k);
+      },
+    },
+    {
+      name: "unified diff - 1K lines, scattered edits",
+      fn() {
+        createUnifiedDiff(oldId, medium1k, newId, medium1kScattered);
+      },
+    },
+    {
+      name: "unified diff - 10K lines, few changes",
+      fn() {
+        createUnifiedDiff(oldId, large10k, newId, large10kFewChanges);
+      },
+    },
+  ],
+};

--- a/benchmarks/index.ts
+++ b/benchmarks/index.ts
@@ -10,6 +10,7 @@
  */
 
 import { bufferBenchmarks } from "./buffer.bench.ts";
+import { diffBenchmarks } from "./diff.bench.ts";
 import { editorBenchmarks } from "./editor.bench.ts";
 import { type BenchmarkSuite, runBenchmarks } from "./harness.ts";
 import { saveHistory } from "./history.ts";
@@ -23,6 +24,7 @@ const suites: BenchmarkSuite[] = [
   viewportBenchmarks,
   wrapMapBenchmarks,
   editorBenchmarks,
+  diffBenchmarks,
 ];
 
 console.log("=".repeat(60));

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "./renderer": {
       "import": "./src/renderer/index.ts",
       "types": "./src/renderer/index.ts"
+    },
+    "./diff": {
+      "import": "./src/diff/index.ts",
+      "types": "./src/diff/index.ts"
     }
   },
   "type": "module",

--- a/src/diff/diff.ts
+++ b/src/diff/diff.ts
@@ -1,0 +1,244 @@
+/**
+ * Line-level diff using Myers' algorithm.
+ *
+ * Produces a minimal edit sequence between two texts, then groups
+ * changes into hunks with configurable context lines.
+ */
+
+import type { DiffHunk, DiffLine, DiffResult } from "./types.ts";
+
+export interface DiffOptions {
+  /** Number of unchanged context lines around each change (default: 3). */
+  context?: number;
+}
+
+/**
+ * Compute a line-level diff between two texts.
+ *
+ * Uses Myers' O(ND) algorithm to find the shortest edit script,
+ * then groups edits into hunks with surrounding context.
+ */
+export function diff(
+  oldText: string,
+  newText: string,
+  options?: DiffOptions,
+): DiffResult {
+  const ctx = options?.context ?? 3;
+  const oldLines = oldText === "" ? [] : oldText.split("\n");
+  const newLines = newText === "" ? [] : newText.split("\n");
+
+  const edits = myersDiff(oldLines, newLines);
+
+  if (edits.every((e) => e.kind === "equal")) {
+    return { hunks: [], isEqual: true };
+  }
+
+  const hunks = buildHunks(edits, ctx);
+  return { hunks, isEqual: false };
+}
+
+/** A raw edit operation from Myers'. */
+interface Edit {
+  kind: "equal" | "insert" | "delete";
+  oldRow: number | undefined;
+  newRow: number | undefined;
+  text: string;
+}
+
+/**
+ * Myers' diff algorithm.
+ * Returns a flat list of edit operations (equal/insert/delete).
+ */
+function myersDiff(oldLines: string[], newLines: string[]): Edit[] {
+  const n = oldLines.length;
+  const m = newLines.length;
+  const max = n + m;
+
+  if (max === 0) return [];
+
+  // V[k] = furthest reaching x on diagonal k
+  // We use offset to handle negative indices: v[k + offset]
+  const offset = max;
+  const size = 2 * max + 1;
+  const v = new Int32Array(size);
+  v.fill(-1);
+  v[1 + offset] = 0;
+
+  // Store the trace for backtracking
+  const trace: Int32Array[] = [];
+
+  // Forward pass: find shortest edit path
+  let found = false;
+  for (let d = 0; d <= max; d++) {
+    trace.push(v.slice());
+
+    for (let k = -d; k <= d; k += 2) {
+      let x: number;
+      if (k === -d || (k !== d && (v[k - 1 + offset] ?? -1) < (v[k + 1 + offset] ?? -1))) {
+        x = v[k + 1 + offset] ?? 0; // move down (insert)
+      } else {
+        x = (v[k - 1 + offset] ?? 0) + 1; // move right (delete)
+      }
+
+      let y = x - k;
+
+      // Follow diagonal (equal lines)
+      while (x < n && y < m && oldLines[x] === newLines[y]) {
+        x++;
+        y++;
+      }
+
+      v[k + offset] = x;
+
+      if (x >= n && y >= m) {
+        found = true;
+        break;
+      }
+    }
+
+    if (found) break;
+  }
+
+  // Backtrack to recover the edit sequence
+  return backtrack(trace, offset, oldLines, newLines);
+}
+
+function backtrack(
+  trace: Int32Array[],
+  offset: number,
+  oldLines: string[],
+  newLines: string[],
+): Edit[] {
+  const n = oldLines.length;
+  const m = newLines.length;
+  let x = n;
+  let y = m;
+  const edits: Edit[] = [];
+
+  for (let d = trace.length - 1; d >= 0; d--) {
+    const v = trace[d];
+    if (!v) continue;
+    const k = x - y;
+
+    let prevK: number;
+    if (k === -d || (k !== d && (v[k - 1 + offset] ?? -1) < (v[k + 1 + offset] ?? -1))) {
+      prevK = k + 1;
+    } else {
+      prevK = k - 1;
+    }
+
+    const prevX = v[prevK + offset] ?? 0;
+    const prevY = prevX - prevK;
+
+    // Diagonal moves (equal lines) — walk backwards
+    while (x > prevX && y > prevY) {
+      x--;
+      y--;
+      edits.push({ kind: "equal", oldRow: x, newRow: y, text: oldLines[x] ?? "" });
+    }
+
+    if (d > 0) {
+      if (x === prevX) {
+        // Insert
+        y--;
+        edits.push({
+          kind: "insert",
+          oldRow: undefined,
+          newRow: y,
+          text: newLines[y] ?? "",
+        });
+      } else {
+        // Delete
+        x--;
+        edits.push({
+          kind: "delete",
+          oldRow: x,
+          newRow: undefined,
+          text: oldLines[x] ?? "",
+        });
+      }
+    }
+  }
+
+  edits.reverse();
+  return edits;
+}
+
+/**
+ * Group a flat edit list into hunks with context lines.
+ * Adjacent changes within `2 * context` lines of each other merge into one hunk.
+ */
+function buildHunks(edits: Edit[], context: number): DiffHunk[] {
+  // Find indices of change operations
+  const changeIndices: number[] = [];
+  for (let i = 0; i < edits.length; i++) {
+    const edit = edits[i];
+    if (edit && edit.kind !== "equal") {
+      changeIndices.push(i);
+    }
+  }
+
+  if (changeIndices.length === 0) return [];
+
+  // Group changes that are close together
+  const groups: { start: number; end: number }[] = [];
+  let groupStart = changeIndices[0] ?? 0;
+  let groupEnd = groupStart;
+
+  for (let i = 1; i < changeIndices.length; i++) {
+    const idx = changeIndices[i] ?? 0;
+    // If the gap between changes is <= 2*context, merge into same group
+    if (idx - groupEnd <= 2 * context) {
+      groupEnd = idx;
+    } else {
+      groups.push({ start: groupStart, end: groupEnd });
+      groupStart = idx;
+      groupEnd = idx;
+    }
+  }
+  groups.push({ start: groupStart, end: groupEnd });
+
+  // Build hunks from groups with context
+  const hunks: DiffHunk[] = [];
+  for (const group of groups) {
+    const hunkStart = Math.max(0, group.start - context);
+    const hunkEnd = Math.min(edits.length - 1, group.end + context);
+
+    const lines: DiffLine[] = [];
+    let oldStart = Number.MAX_SAFE_INTEGER;
+    let newStart = Number.MAX_SAFE_INTEGER;
+    let oldCount = 0;
+    let newCount = 0;
+
+    for (let i = hunkStart; i <= hunkEnd; i++) {
+      const edit = edits[i];
+      if (!edit) continue;
+
+      lines.push({
+        kind: edit.kind,
+        text: edit.text,
+        oldRow: edit.oldRow,
+        newRow: edit.newRow,
+      });
+
+      if (edit.kind !== "insert" && edit.oldRow !== undefined) {
+        oldStart = Math.min(oldStart, edit.oldRow);
+        oldCount++;
+      }
+      if (edit.kind !== "delete" && edit.newRow !== undefined) {
+        newStart = Math.min(newStart, edit.newRow);
+        newCount++;
+      }
+    }
+
+    hunks.push({
+      oldStart: oldStart === Number.MAX_SAFE_INTEGER ? 0 : oldStart,
+      oldCount,
+      newStart: newStart === Number.MAX_SAFE_INTEGER ? 0 : newStart,
+      newCount,
+      lines,
+    });
+  }
+
+  return hunks;
+}

--- a/src/diff/index.ts
+++ b/src/diff/index.ts
@@ -1,0 +1,5 @@
+export type { DiffOptions } from "./diff.ts";
+export { diff } from "./diff.ts";
+export type { DiffHunk, DiffKind, DiffLine, DiffResult } from "./types.ts";
+export type { DiffStats, UnifiedDiff, UnifiedDiffLine } from "./unified.ts";
+export { createUnifiedDiff } from "./unified.ts";

--- a/src/diff/types.ts
+++ b/src/diff/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Types for the diff module.
+ *
+ * A diff operates on two text snapshots (old and new) and produces
+ * a sequence of hunks describing how they differ.
+ */
+
+/** The kind of change a diff line represents. */
+export type DiffKind = "equal" | "insert" | "delete";
+
+/** A single line in a diff result with its origin. */
+export interface DiffLine {
+  readonly kind: DiffKind;
+  /** The line text (without trailing newline). */
+  readonly text: string;
+  /** Line number in the old buffer (undefined for inserts). */
+  readonly oldRow: number | undefined;
+  /** Line number in the new buffer (undefined for deletes). */
+  readonly newRow: number | undefined;
+}
+
+/**
+ * A contiguous group of diff lines with shared context.
+ * Analogous to a unified diff hunk (`@@ -a,b +c,d @@`).
+ */
+export interface DiffHunk {
+  /** Starting line in the old buffer. */
+  readonly oldStart: number;
+  /** Number of lines from the old buffer in this hunk. */
+  readonly oldCount: number;
+  /** Starting line in the new buffer. */
+  readonly newStart: number;
+  /** Number of lines from the new buffer in this hunk. */
+  readonly newCount: number;
+  /** The lines in this hunk (context + changes). */
+  readonly lines: readonly DiffLine[];
+}
+
+/**
+ * Complete diff result between two texts.
+ */
+export interface DiffResult {
+  /** The hunks describing all changes. */
+  readonly hunks: readonly DiffHunk[];
+  /** True if the two texts are identical. */
+  readonly isEqual: boolean;
+}

--- a/src/diff/unified.ts
+++ b/src/diff/unified.ts
@@ -1,0 +1,129 @@
+/**
+ * Unified diff view.
+ *
+ * Takes two texts and produces a flat list of lines suitable for rendering
+ * in a single scrollable view. Deleted lines, inserted lines, and unchanged
+ * context are interleaved — like `git diff` output.
+ *
+ * Each line tracks which source buffer it came from and its row in that buffer,
+ * so the renderer can map clicks/selections back to the original files.
+ */
+
+import type { BufferId } from "../buffer/types.ts";
+import type { DiffOptions } from "./diff.ts";
+import { diff } from "./diff.ts";
+import type { DiffKind } from "./types.ts";
+
+/** A single line in the unified diff view. */
+export interface UnifiedDiffLine {
+  /** Whether this line is equal, inserted, or deleted. */
+  readonly kind: DiffKind;
+  /** The line text. */
+  readonly text: string;
+  /** Which buffer this line comes from. */
+  readonly bufferId: BufferId;
+  /** Row in the source buffer. */
+  readonly sourceRow: number;
+}
+
+/** Summary statistics for a diff. */
+export interface DiffStats {
+  readonly inserts: number;
+  readonly deletes: number;
+  readonly equal: number;
+}
+
+/** The result of building a unified diff view. */
+export interface UnifiedDiff {
+  /** All lines in display order. */
+  readonly lines: readonly UnifiedDiffLine[];
+  /** Total number of lines in the unified view. */
+  readonly lineCount: number;
+  /** Change statistics. */
+  readonly stats: DiffStats;
+  /** True if old and new are identical. */
+  readonly isEqual: boolean;
+}
+
+/**
+ * Create a unified diff view from two texts.
+ *
+ * For equal files, returns all lines as "equal" referencing the new buffer.
+ * For changed files, interleaves delete/insert/equal lines with context.
+ */
+export function createUnifiedDiff(
+  oldBufferId: BufferId,
+  oldText: string,
+  newBufferId: BufferId,
+  newText: string,
+  options?: DiffOptions,
+): UnifiedDiff {
+  const result = diff(oldText, newText, options);
+
+  if (result.isEqual) {
+    // Identical — show all lines as equal, referencing new buffer
+    const newLines = newText === "" ? [] : newText.split("\n");
+    const lines: UnifiedDiffLine[] = newLines.map((text, i) => ({
+      kind: "equal" as const,
+      text,
+      bufferId: newBufferId,
+      sourceRow: i,
+    }));
+    return {
+      lines,
+      lineCount: lines.length,
+      stats: { inserts: 0, deletes: 0, equal: lines.length },
+      isEqual: true,
+    };
+  }
+
+  // Build unified view from hunks
+  const lines: UnifiedDiffLine[] = [];
+  let inserts = 0;
+  let deletes = 0;
+  let equal = 0;
+
+  for (const hunk of result.hunks) {
+    for (const line of hunk.lines) {
+      switch (line.kind) {
+        case "delete":
+          lines.push({
+            kind: "delete",
+            text: line.text,
+            bufferId: oldBufferId,
+            // biome-ignore lint/plugin/no-type-assertion: expect: oldRow is always defined for deletes
+            sourceRow: line.oldRow as number,
+          });
+          deletes++;
+          break;
+        case "insert":
+          lines.push({
+            kind: "insert",
+            text: line.text,
+            bufferId: newBufferId,
+            // biome-ignore lint/plugin/no-type-assertion: expect: newRow is always defined for inserts
+            sourceRow: line.newRow as number,
+          });
+          inserts++;
+          break;
+        case "equal":
+          lines.push({
+            kind: "equal",
+            text: line.text,
+            bufferId: newBufferId,
+            // biome-ignore lint/plugin/no-type-assertion: expect: newRow is always defined for equal lines
+            sourceRow: line.newRow as number,
+          });
+          equal++;
+          break;
+      }
+    }
+  }
+
+  return {
+    lines,
+    lineCount: lines.length,
+    stats: { inserts, deletes, equal },
+    isEqual: false,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Main entry point — re-exports everything for "multibuffer" root import
 
 export * from "./buffer/index.ts";
+export * from "./diff/index.ts";
 export * from "./editor/index.ts";
 export * from "./multibuffer/index.ts";
 export * from "./renderer/index.ts";

--- a/tests/diff/diff.test.ts
+++ b/tests/diff/diff.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the line-level diff algorithm.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { diff } from "../../src/diff/diff.ts";
+
+describe("diff", () => {
+  test("identical texts produce no hunks", () => {
+    const result = diff("hello\nworld", "hello\nworld");
+    expect(result.isEqual).toBe(true);
+    expect(result.hunks).toEqual([]);
+  });
+
+  test("empty to non-empty is all inserts", () => {
+    const result = diff("", "a\nb");
+    expect(result.isEqual).toBe(false);
+    expect(result.hunks.length).toBe(1);
+    const hunk = result.hunks[0];
+    if (!hunk) throw new Error("expected hunk");
+    expect(hunk.lines.length).toBe(2);
+    expect(hunk.lines[0]).toEqual({ kind: "insert", text: "a", oldRow: undefined, newRow: 0 });
+    expect(hunk.lines[1]).toEqual({ kind: "insert", text: "b", oldRow: undefined, newRow: 1 });
+  });
+
+  test("non-empty to empty is all deletes", () => {
+    const result = diff("a\nb", "");
+    expect(result.isEqual).toBe(false);
+    expect(result.hunks.length).toBe(1);
+    const hunk = result.hunks[0];
+    if (!hunk) throw new Error("expected hunk");
+    expect(hunk.lines.length).toBe(2);
+    expect(hunk.lines[0]).toEqual({ kind: "delete", text: "a", oldRow: 0, newRow: undefined });
+    expect(hunk.lines[1]).toEqual({ kind: "delete", text: "b", oldRow: 1, newRow: undefined });
+  });
+
+  test("single line change", () => {
+    const result = diff("hello\nworld", "hello\nearth");
+    expect(result.isEqual).toBe(false);
+    expect(result.hunks.length).toBe(1);
+    const hunk = result.hunks[0];
+    if (!hunk) throw new Error("expected hunk");
+    const kinds = hunk.lines.map((l) => l.kind);
+    expect(kinds).toContain("delete");
+    expect(kinds).toContain("insert");
+    expect(kinds).toContain("equal");
+  });
+
+  test("insertion in the middle", () => {
+    const result = diff("a\nc", "a\nb\nc");
+    expect(result.isEqual).toBe(false);
+    const allLines = result.hunks.flatMap((h) => h.lines);
+    const insertLines = allLines.filter((l) => l.kind === "insert");
+    expect(insertLines.length).toBe(1);
+    const ins = insertLines[0];
+    if (!ins) throw new Error("expected insert");
+    expect(ins.text).toBe("b");
+    expect(ins.newRow).toBe(1);
+  });
+
+  test("deletion in the middle", () => {
+    const result = diff("a\nb\nc", "a\nc");
+    expect(result.isEqual).toBe(false);
+    const allLines = result.hunks.flatMap((h) => h.lines);
+    const deleteLines = allLines.filter((l) => l.kind === "delete");
+    expect(deleteLines.length).toBe(1);
+    const del = deleteLines[0];
+    if (!del) throw new Error("expected delete");
+    expect(del.text).toBe("b");
+    expect(del.oldRow).toBe(1);
+  });
+
+  test("hunk counts match line counts", () => {
+    const result = diff("a\nb\nc\nd", "a\nx\nc\ny");
+    for (const hunk of result.hunks) {
+      const oldLines = hunk.lines.filter((l) => l.kind !== "insert").length;
+      const newLines = hunk.lines.filter((l) => l.kind !== "delete").length;
+      expect(oldLines).toBe(hunk.oldCount);
+      expect(newLines).toBe(hunk.newCount);
+    }
+  });
+
+  test("multiple separate changes produce separate hunks with enough context gap", () => {
+    const old = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
+    const lines = old.split("\n");
+    lines[2] = "changed 2";
+    lines[17] = "changed 17";
+    const result = diff(old, lines.join("\n"));
+    expect(result.hunks.length).toBe(2);
+  });
+
+  test("both empty texts are equal", () => {
+    const result = diff("", "");
+    expect(result.isEqual).toBe(true);
+    expect(result.hunks).toEqual([]);
+  });
+
+  test("context lines default to 3", () => {
+    const old = Array.from({ length: 10 }, (_, i) => `line ${i}`).join("\n");
+    const lines = old.split("\n");
+    lines[5] = "changed";
+    const result = diff(old, lines.join("\n"));
+    expect(result.hunks.length).toBe(1);
+    const hunk = result.hunks[0];
+    if (!hunk) throw new Error("expected hunk");
+    const equalBefore = hunk.lines.filter(
+      (l, i) => l.kind === "equal" && i < hunk.lines.findIndex((x) => x.kind !== "equal"),
+    );
+    expect(equalBefore.length).toBeLessThanOrEqual(3);
+  });
+
+  test("custom context lines", () => {
+    const old = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
+    const lines = old.split("\n");
+    lines[10] = "changed";
+    const result = diff(old, lines.join("\n"), { context: 1 });
+    const hunk = result.hunks[0];
+    if (!hunk) throw new Error("expected hunk");
+    const equalBefore = hunk.lines.filter(
+      (l, i) => l.kind === "equal" && i < hunk.lines.findIndex((x) => x.kind !== "equal"),
+    );
+    expect(equalBefore.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/diff/unified.test.ts
+++ b/tests/diff/unified.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for unified diff view.
+ *
+ * A unified diff renders old and new content in a single scrollable view,
+ * with deleted lines, inserted lines, and unchanged context interleaved.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { BufferId } from "../../src/buffer/types.ts";
+import { createUnifiedDiff } from "../../src/diff/unified.ts";
+
+// biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in tests
+const oldId = "old.ts" as BufferId;
+// biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in tests
+const newId = "new.ts" as BufferId;
+
+describe("createUnifiedDiff", () => {
+  test("identical texts produce all equal lines", () => {
+    const text = "hello\nworld";
+    const result = createUnifiedDiff(oldId, text, newId, text);
+    expect(result.lines.length).toBe(2);
+    expect(result.lines.every((l) => l.kind === "equal")).toBe(true);
+    const first = result.lines[0];
+    const second = result.lines[1];
+    if (!first || !second) throw new Error("expected 2 lines");
+    expect(first.text).toBe("hello");
+    expect(second.text).toBe("world");
+  });
+
+  test("single line change shows delete then insert", () => {
+    const result = createUnifiedDiff(oldId, "a\nb\nc", newId, "a\nB\nc");
+    const changed = result.lines.filter((l) => l.kind !== "equal");
+    expect(changed.length).toBe(2);
+    const del = changed[0];
+    const ins = changed[1];
+    if (!del || !ins) throw new Error("expected delete and insert");
+    expect(del.kind).toBe("delete");
+    expect(del.text).toBe("b");
+    expect(ins.kind).toBe("insert");
+    expect(ins.text).toBe("B");
+  });
+
+  test("lines track source buffer and row", () => {
+    const result = createUnifiedDiff(oldId, "a\nb", newId, "a\nc");
+    const deleteLine = result.lines.find((l) => l.kind === "delete");
+    const insertLine = result.lines.find((l) => l.kind === "insert");
+    if (!deleteLine || !insertLine) throw new Error("expected delete and insert");
+    expect(deleteLine.bufferId).toBe(oldId);
+    expect(deleteLine.sourceRow).toBe(1);
+    expect(insertLine.bufferId).toBe(newId);
+    expect(insertLine.sourceRow).toBe(1);
+  });
+
+  test("equal lines reference the new buffer", () => {
+    const result = createUnifiedDiff(oldId, "same\nline", newId, "same\nline");
+    for (const line of result.lines) {
+      expect(line.bufferId).toBe(newId);
+    }
+  });
+
+  test("pure insertion", () => {
+    const result = createUnifiedDiff(oldId, "a\nc", newId, "a\nb\nc");
+    const inserts = result.lines.filter((l) => l.kind === "insert");
+    expect(inserts.length).toBe(1);
+    const ins = inserts[0];
+    if (!ins) throw new Error("expected insert");
+    expect(ins.text).toBe("b");
+  });
+
+  test("pure deletion", () => {
+    const result = createUnifiedDiff(oldId, "a\nb\nc", newId, "a\nc");
+    const deletes = result.lines.filter((l) => l.kind === "delete");
+    expect(deletes.length).toBe(1);
+    const del = deletes[0];
+    if (!del) throw new Error("expected delete");
+    expect(del.text).toBe("b");
+  });
+
+  test("empty old to non-empty new", () => {
+    const result = createUnifiedDiff(oldId, "", newId, "hello\nworld");
+    expect(result.lines.length).toBe(2);
+    expect(result.lines.every((l) => l.kind === "insert")).toBe(true);
+  });
+
+  test("line count matches total unified lines", () => {
+    const result = createUnifiedDiff(
+      oldId,
+      "a\nb\nc\nd",
+      newId,
+      "a\nB\nc\nD",
+    );
+    // a(equal) + b(delete) + B(insert) + c(equal) + d(delete) + D(insert)
+    expect(result.lines.length).toBe(6);
+    expect(result.lineCount).toBe(6);
+  });
+
+  test("stats track insert and delete counts", () => {
+    const result = createUnifiedDiff(
+      oldId,
+      "a\nb\nc",
+      newId,
+      "a\nB\nC\nd",
+    );
+    expect(result.stats.inserts).toBeGreaterThan(0);
+    expect(result.stats.deletes).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/diff/` module with `multibuffer/diff` subpath export
- **Myers' O(ND) algorithm** for line-level diffing with configurable context lines
- **Unified diff view** — interleaves delete/insert/equal lines with source buffer + row tracking
- 20 tests, 9 benchmarks across various file sizes and change patterns

### Performance
| Scenario | Avg |
|---|---|
| 100 lines, 5 changes | 0.013ms |
| 1K lines, scattered edits | 0.110ms |
| 10K lines, few changes | 0.687ms |
| 1K full rewrite (worst case) | 15.7ms |

### API
```ts
import { diff, createUnifiedDiff } from "multibuffer/diff";

const result = diff(oldText, newText, { context: 3 });
const unified = createUnifiedDiff(oldId, oldText, newId, newText);
// unified.lines → [{ kind, text, bufferId, sourceRow }, ...]
```

Relates to #101

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean  
- [x] `bun test` — 752 tests, 742 pass, 10 todo, 0 fail
- [x] `bun run bench` — all diff benchmarks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)