### PR TITLE
feat(playground): add unified diff demo scenarios

### DIFF
--- a/playground/demo.ts
+++ b/playground/demo.ts
@@ -3,11 +3,12 @@
  */
 
 import { createBuffer } from "../src/buffer/buffer.ts";
+import type { BufferId } from "../src/buffer/types.ts";
+import { createUnifiedDiff } from "../src/diff/unified.ts";
 import { Editor } from "../src/editor/editor.ts";
 import { InputHandler } from "../src/editor/input-handler.ts";
 import { createMultiBuffer } from "../src/multibuffer/multibuffer.ts";
 import type {
-  BufferId,
   BufferPoint,
   BufferRow,
   Buffer as MbBuffer,
@@ -18,6 +19,7 @@ import { createDomRenderer } from "../src/renderer/dom.ts";
 import { Highlighter } from "../src/renderer/highlighter.ts";
 import { createViewport } from "../src/renderer/measurement.ts";
 import type { Measurements } from "../src/renderer/types.ts";
+import { mountDiffView } from "./diff-renderer.ts";
 import { sources } from "./sources.gen.ts";
 
 /** Identifies a named fixture scenario in the demo. */
@@ -28,11 +30,15 @@ type ScenarioId =
   | "unicode"
   | "long-lines"
   | "empty"
-  | "single-line";
+  | "single-line"
+  | "diff-single"
+  | "diff-multi";
 
 interface Scenario {
   readonly id: ScenarioId;
   readonly label: string;
+  /** If true, this scenario renders a diff view instead of the editor. */
+  readonly isDiff?: boolean;
   build(m: MultiBuffer): void;
 }
 
@@ -330,21 +336,160 @@ async function main() {
         });
       },
     },
+    {
+      id: "diff-single",
+      label: "Unified Diff (single)",
+      isDiff: true,
+      build() {
+        // no-op: diff scenarios render via mountDiffView
+      },
+    },
+    {
+      id: "diff-multi",
+      label: "Unified Diff (multi)",
+      isDiff: true,
+      build() {
+        // no-op: diff scenarios render via mountDiffView
+      },
+    },
   ];
 
   let activeScenarioId: ScenarioId = "all";
+  let diffUnmount: (() => void) | null = null;
+
+  // Scroll container created by the DomRenderer — we toggle its visibility for diff mode
+  const scrollContainer = container.firstElementChild;
 
   function switchScenario(id: ScenarioId): void {
     if (id === activeScenarioId) return;
     activeScenarioId = id;
-    const toRemove = mb.excerpts.map((e) => e.id);
-    for (const excerptId of toRemove) {
-      mb.removeExcerpt(excerptId);
+
+    // Clean up previous diff view if any
+    if (diffUnmount) {
+      diffUnmount();
+      diffUnmount = null;
     }
+
     const scenario = scenarios.find((s) => s.id === id);
-    scenario?.build(mb);
+    if (!scenario) return;
+
+    if (scenario.isDiff) {
+      // Hide the editor scroll container
+      if (scrollContainer instanceof HTMLElement) {
+        scrollContainer.style.display = "none";
+      }
+      if (container) diffUnmount = renderDiffScenario(id, container);
+    } else {
+      // Show the editor scroll container
+      if (scrollContainer instanceof HTMLElement) {
+        scrollContainer.style.display = "";
+      }
+      const toRemove = mb.excerpts.map((e) => e.id);
+      for (const excerptId of toRemove) {
+        mb.removeExcerpt(excerptId);
+      }
+      scenario.build(mb);
+      // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
+      editor.setCursor({ row: 0 as MultiBufferRow, column: 0 });
+    }
+  }
+
+  function renderDiffScenario(
+    id: ScenarioId,
+    target: HTMLElement,
+  ): () => void {
+    if (id === "diff-single") {
+      return renderSingleBufferDiff(target);
+    }
+    return renderMultiBufferDiff(target);
+  }
+
+  function renderSingleBufferDiff(target: HTMLElement): () => void {
+    // Use the first source file and create a modified version
+    const src = sources[0];
+    if (!src) return () => {};
+
+    const oldText = src.content;
+    const oldLines = oldText.split("\n");
+    const newLines = [...oldLines];
+
+    // Simulate realistic edits: modify some lines, add some, remove some
+    if (newLines.length > 3) {
+      newLines[2] = `${newLines[2]} // updated`;
+    }
+    if (newLines.length > 8) {
+      newLines.splice(8, 0, "// NEW: inserted line", "// NEW: another inserted line");
+    }
+    if (newLines.length > 5) {
+      newLines.splice(5, 1); // delete one line
+    }
+    const newText = newLines.join("\n");
+
     // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
-    editor.setCursor({ row: 0 as MultiBufferRow, column: 0 });
+    const oldId = `${src.path} (before)` as BufferId;
+    // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
+    const newId = `${src.path} (after)` as BufferId;
+
+    const diff = createUnifiedDiff(oldId, oldText, newId, newText);
+    return mountDiffView(target, [{ label: src.path, diff }]);
+  }
+
+  function renderMultiBufferDiff(target: HTMLElement): () => void {
+    const files: Array<{ label: string; diff: ReturnType<typeof createUnifiedDiff> }> = [];
+
+    // Create diffs for up to 4 source files with varied edit patterns
+    const editPatterns = [
+      // Pattern 0: modify a few lines
+      (lines: string[]) => {
+        const out = [...lines];
+        if (out.length > 2) out[1] = `${out[1]} // refactored`;
+        if (out.length > 6) out[5] = `${out[5]} // updated`;
+        return out;
+      },
+      // Pattern 1: add lines
+      (lines: string[]) => {
+        const out = [...lines];
+        const insertAt = Math.min(4, out.length);
+        out.splice(insertAt, 0, "  // TODO: handle edge case", "  // TODO: add tests");
+        return out;
+      },
+      // Pattern 2: remove lines
+      (lines: string[]) => {
+        const out = [...lines];
+        if (out.length > 10) out.splice(3, 2);
+        return out;
+      },
+      // Pattern 3: mixed edits
+      (lines: string[]) => {
+        const out = [...lines];
+        if (out.length > 4) out[3] = "  // rewritten logic";
+        if (out.length > 8) out.splice(7, 1);
+        if (out.length > 6) out.splice(5, 0, "  // added validation");
+        return out;
+      },
+    ];
+
+    const maxFiles = Math.min(4, sources.length);
+    for (let i = 0; i < maxFiles; i++) {
+      const src = sources[i];
+      if (!src) continue;
+
+      const pattern = editPatterns[i % editPatterns.length];
+      if (!pattern) continue;
+
+      const oldLines = src.content.split("\n");
+      const newLines = pattern(oldLines);
+
+      // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
+      const oldId = `${src.path} (old)` as BufferId;
+      // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
+      const newId = `${src.path} (new)` as BufferId;
+
+      const diff = createUnifiedDiff(oldId, src.content, newId, newLines.join("\n"));
+      files.push({ label: src.path, diff });
+    }
+
+    return mountDiffView(target, files);
   }
 
   function createScenarioPicker(): HTMLElement {

--- a/playground/diff-renderer.ts
+++ b/playground/diff-renderer.ts
@@ -1,0 +1,196 @@
+/**
+ * Lightweight DOM renderer for unified diff views.
+ *
+ * Renders a scrollable list of diff lines with:
+ * - Color-coded backgrounds (red for deletes, green for inserts)
+ * - Dual gutter showing old/new line numbers
+ * - File headers with change statistics
+ */
+
+import type { UnifiedDiff, UnifiedDiffLine } from "../src/diff/unified.ts";
+
+/** Gruvbox-inspired diff colors */
+const COLORS = {
+  deleteBg: "rgba(204, 36, 29, 0.15)",
+  deleteGutter: "rgba(204, 36, 29, 0.25)",
+  deleteText: "#fb4934",
+  deleteSign: "#cc241d",
+  insertBg: "rgba(152, 151, 26, 0.15)",
+  insertGutter: "rgba(152, 151, 26, 0.25)",
+  insertText: "#b8bb26",
+  insertSign: "#98971a",
+  equalText: "#ebdbb2",
+  gutterText: "#665c54",
+  headerBg: "#3c3836",
+  headerBorder: "#504945",
+  headerText: "#a89984",
+  statInsert: "#b8bb26",
+  statDelete: "#fb4934",
+} as const;
+
+interface DiffFileEntry {
+  readonly label: string;
+  readonly diff: UnifiedDiff;
+}
+
+/**
+ * Mount a unified diff view into a container element.
+ * Returns an unmount function.
+ */
+export function mountDiffView(
+  container: HTMLElement,
+  files: readonly DiffFileEntry[],
+): () => void {
+  const scrollContainer = document.createElement("div");
+  scrollContainer.style.cssText =
+    "position:relative;overflow-y:auto;height:100%;width:100%;overscroll-behavior:none;";
+
+  const content = document.createElement("div");
+  content.style.cssText = "padding:0;";
+
+  for (const file of files) {
+    content.appendChild(renderFileHeader(file.label, file.diff));
+    content.appendChild(renderDiffLines(file.diff.lines));
+  }
+
+  scrollContainer.appendChild(content);
+  container.appendChild(scrollContainer);
+
+  return () => {
+    container.removeChild(scrollContainer);
+  };
+}
+
+function renderFileHeader(label: string, diff: UnifiedDiff): HTMLElement {
+  const header = document.createElement("div");
+  header.style.cssText = [
+    `background:${COLORS.headerBg}`,
+    `border-bottom:1px solid ${COLORS.headerBorder}`,
+    "padding:8px 12px",
+    "display:flex",
+    "align-items:center",
+    "gap:12px",
+    "position:sticky",
+    "top:0",
+    "z-index:10",
+  ].join(";");
+
+  const pathEl = document.createElement("span");
+  pathEl.textContent = label;
+  pathEl.style.cssText = `color:${COLORS.headerText};font-weight:bold;font-size:0.9em;flex:1;`;
+
+  const statsEl = document.createElement("span");
+  statsEl.style.cssText = "font-size:0.85em;display:flex;gap:8px;";
+
+  if (diff.isEqual) {
+    const eq = document.createElement("span");
+    eq.textContent = "No changes";
+    eq.style.color = COLORS.gutterText;
+    statsEl.appendChild(eq);
+  } else {
+    if (diff.stats.inserts > 0) {
+      const ins = document.createElement("span");
+      ins.textContent = `+${diff.stats.inserts}`;
+      ins.style.color = COLORS.statInsert;
+      statsEl.appendChild(ins);
+    }
+    if (diff.stats.deletes > 0) {
+      const del = document.createElement("span");
+      del.textContent = `\u2212${diff.stats.deletes}`;
+      del.style.color = COLORS.statDelete;
+      statsEl.appendChild(del);
+    }
+  }
+
+  header.appendChild(pathEl);
+  header.appendChild(statsEl);
+  return header;
+}
+
+function renderDiffLines(lines: readonly UnifiedDiffLine[]): HTMLElement {
+  const wrapper = document.createElement("div");
+  wrapper.style.cssText = "margin-bottom:16px;";
+
+  // Track separate old/new line counters for accurate dual-gutter display.
+  // Each line kind advances its respective counter(s).
+  let oldLineNum = 0;
+  let newLineNum = 0;
+
+  // Seed counters from first line of each kind
+  for (const line of lines) {
+    if (line.kind === "delete" || line.kind === "equal") {
+      oldLineNum = line.sourceRow;
+      break;
+    }
+  }
+  for (const line of lines) {
+    if (line.kind === "insert" || line.kind === "equal") {
+      newLineNum = line.sourceRow;
+      break;
+    }
+  }
+
+  for (const line of lines) {
+    const row = document.createElement("div");
+    row.style.cssText = "display:flex;height:20px;line-height:20px;white-space:pre;";
+
+    const oldGutter = document.createElement("span");
+    oldGutter.style.cssText =
+      `display:inline-block;width:40px;text-align:right;padding-right:4px;color:${COLORS.gutterText};user-select:none;flex-shrink:0;font-size:0.9em;`;
+
+    const newGutter = document.createElement("span");
+    newGutter.style.cssText =
+      `display:inline-block;width:40px;text-align:right;padding-right:4px;color:${COLORS.gutterText};user-select:none;flex-shrink:0;font-size:0.9em;`;
+
+    const sign = document.createElement("span");
+    sign.style.cssText =
+      "display:inline-block;width:16px;text-align:center;user-select:none;flex-shrink:0;";
+
+    const text = document.createElement("span");
+    text.style.cssText = "flex:1;overflow:hidden;padding-left:4px;";
+    text.textContent = line.text;
+
+    switch (line.kind) {
+      case "delete":
+        row.style.background = COLORS.deleteBg;
+        oldGutter.style.background = COLORS.deleteGutter;
+        oldGutter.textContent = String(oldLineNum + 1);
+        newGutter.textContent = "";
+        newGutter.style.background = COLORS.deleteGutter;
+        sign.textContent = "\u2212";
+        sign.style.color = COLORS.deleteSign;
+        sign.style.background = COLORS.deleteBg;
+        text.style.color = COLORS.deleteText;
+        oldLineNum++;
+        break;
+      case "insert":
+        row.style.background = COLORS.insertBg;
+        oldGutter.textContent = "";
+        oldGutter.style.background = COLORS.insertGutter;
+        newGutter.style.background = COLORS.insertGutter;
+        newGutter.textContent = String(newLineNum + 1);
+        sign.textContent = "+";
+        sign.style.color = COLORS.insertSign;
+        sign.style.background = COLORS.insertBg;
+        text.style.color = COLORS.insertText;
+        newLineNum++;
+        break;
+      case "equal":
+        oldGutter.textContent = String(oldLineNum + 1);
+        newGutter.textContent = String(newLineNum + 1);
+        sign.textContent = " ";
+        text.style.color = COLORS.equalText;
+        oldLineNum++;
+        newLineNum++;
+        break;
+    }
+
+    row.appendChild(oldGutter);
+    row.appendChild(newGutter);
+    row.appendChild(sign);
+    row.appendChild(text);
+    wrapper.appendChild(row);
+  }
+
+  return wrapper;
+}


### PR DESCRIPTION
## Summary
- Adds two new scenarios to the playground fixture picker: **Unified Diff (single)** and **Unified Diff (multi)**
- Creates `playground/diff-renderer.ts` — a lightweight DOM renderer for unified diffs with color-coded lines (gruvbox-inspired), dual gutters (old/new line numbers), change signs (+/−), and sticky file headers with insert/delete stats
- Single-buffer demo diffs a source file against a simulated edit; multi-buffer demo shows diffs across up to 4 source files with varied edit patterns
- Diff scenarios toggle the editor view off and render the diff view directly in the `#editor` container

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] `bun test` — 742 pass, 0 fail
- [x] `bun run build:playground` — builds successfully
- [ ] Open `bun run dev`, click "Unified Diff (single)" in the fixture picker — verify colored diff view appears
- [ ] Click "Unified Diff (multi)" — verify multiple file diffs render with headers and stats
- [ ] Switch back to "All files" — verify normal editor view restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)