### PR TITLE
feat: add non-editable excerpts

### DIFF
--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -409,7 +409,7 @@ export class Editor {
       // Replace selection with text
       const range = resolveAnchorRange(snap, this._selection.range);
       if (range) {
-        this._edit(snap, range.start, range.end, insertText);
+        if (!this._edit(snap, range.start, range.end, insertText)) return;
         const newSnap = this.multiBuffer.snapshot();
         const newCursor = this._advancePoint(range.start, insertText, newSnap);
         this._cursor = newCursor;
@@ -420,7 +420,7 @@ export class Editor {
 
     // Insert at cursor
     const cursor = this.cursor;
-    this._edit(snap, cursor, cursor, insertText);
+    if (!this._edit(snap, cursor, cursor, insertText)) return;
     const newSnap = this.multiBuffer.snapshot();
     const newCursor = this._advancePoint(cursor, insertText, newSnap);
     this._cursor = newCursor;
@@ -432,7 +432,7 @@ export class Editor {
     if (this._selection && !isCollapsed(snap, this._selection)) {
       const range = resolveAnchorRange(snap, this._selection.range);
       if (range) {
-        this._edit(snap, range.start, range.end, "");
+        if (!this._edit(snap, range.start, range.end, "")) return;
         this._cursor = range.start;
         this._selection = selectionAtPoint(this.multiBuffer, range.start);
       }
@@ -442,7 +442,7 @@ export class Editor {
     const cursor = this.cursor;
     const target = moveCursor(snap, cursor, "left", granularity);
     if (target.row !== cursor.row || target.column !== cursor.column) {
-      this._edit(snap, target, cursor, "");
+      if (!this._edit(snap, target, cursor, "")) return;
       this._cursor = target;
       this._selection = selectionAtPoint(this.multiBuffer, target);
     }
@@ -453,7 +453,7 @@ export class Editor {
     if (this._selection && !isCollapsed(snap, this._selection)) {
       const range = resolveAnchorRange(snap, this._selection.range);
       if (range) {
-        this._edit(snap, range.start, range.end, "");
+        if (!this._edit(snap, range.start, range.end, "")) return;
         this._cursor = range.start;
         this._selection = selectionAtPoint(this.multiBuffer, range.start);
       }
@@ -463,7 +463,7 @@ export class Editor {
     const cursor = this.cursor;
     const target = moveCursor(snap, cursor, "right", granularity);
     if (target.row !== cursor.row || target.column !== cursor.column) {
-      this._edit(snap, cursor, target, "");
+      if (!this._edit(snap, cursor, target, "")) return;
       this._selection = selectionAtPoint(this.multiBuffer, cursor);
     }
   }
@@ -664,7 +664,7 @@ export class Editor {
       newCursorRow = prevRow;
     }
 
-    this._edit(snap, deleteStart, deleteEnd, "");
+    if (!this._edit(snap, deleteStart, deleteEnd, "")) return;
     const newCursor: MultiBufferPoint = { row: newCursorRow, column: 0 };
     this._cursor = newCursor;
     this._selection = selectionAtPoint(this.multiBuffer, newCursor);
@@ -694,7 +694,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
 
       const editStart: MultiBufferPoint = { row, column: 0 };
       const editEnd: MultiBufferPoint = { row: belowRow, column: belowLineText.length };
-      this._edit(snap, editStart, editEnd, `${belowLineText}\n${currentLineText}`);
+      if (!this._edit(snap, editStart, editEnd, `${belowLineText}\n${currentLineText}`)) return;
 
       const newCursor: MultiBufferPoint = { row: belowRow, column: cursor.column };
       this._cursor = newCursor;
@@ -706,7 +706,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
 
       const editStart: MultiBufferPoint = { row: aboveRow, column: 0 };
       const editEnd: MultiBufferPoint = { row, column: currentLineText.length };
-      this._edit(snap, editStart, editEnd, `${currentLineText}\n${aboveLineText}`);
+      if (!this._edit(snap, editStart, editEnd, `${currentLineText}\n${aboveLineText}`)) return;
 
       const newCursor: MultiBufferPoint = { row: aboveRow, column: cursor.column };
       this._cursor = newCursor;
@@ -725,7 +725,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
 
     if (direction === "down") {
       const insertPoint: MultiBufferPoint = { row, column: currentLineText.length };
-      this._edit(snap, insertPoint, insertPoint, `\n${currentLineText}`);
+      if (!this._edit(snap, insertPoint, insertPoint, `\n${currentLineText}`)) return;
 
       // biome-ignore lint/plugin/no-type-assertion: expect: branded arithmetic
       const newCursor: MultiBufferPoint = { row: (row + 1) as MultiBufferRow, column: cursor.column };
@@ -733,7 +733,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
       this._selection = selectionAtPoint(this.multiBuffer, newCursor);
     } else {
       const insertPoint: MultiBufferPoint = { row, column: 0 };
-      this._edit(snap, insertPoint, insertPoint, `${currentLineText}\n`);
+      if (!this._edit(snap, insertPoint, insertPoint, `${currentLineText}\n`)) return;
 
       this._cursor = { row, column: cursor.column };
       this._selection = selectionAtPoint(this.multiBuffer, this._cursor);
@@ -753,7 +753,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
     const indent = currentLineText.match(/^( +)/)?.[1] ?? "";
 
     const insertPoint: MultiBufferPoint = { row, column: currentLineText.length };
-    this._edit(snap, insertPoint, insertPoint, `\n${indent}`);
+    if (!this._edit(snap, insertPoint, insertPoint, `\n${indent}`)) return;
 
     // Move cursor to the new line after any indentation
     // biome-ignore lint/plugin/no-type-assertion: expect: branded arithmetic
@@ -774,7 +774,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
 
     // Insert the indented blank line before the current line
     const insertPoint: MultiBufferPoint = { row, column: 0 };
-    this._edit(snap, insertPoint, insertPoint, `${indent}\n`);
+    if (!this._edit(snap, insertPoint, insertPoint, `${indent}\n`)) return;
 
     // Cursor moves to the new blank line after any indentation
     const newCursor: MultiBufferPoint = { row, column: indent.length };
@@ -798,7 +798,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
     const lastLineLen = lines[lines.length - 1]?.length ?? 0;
     const rangeEnd: MultiBufferPoint = { row: endRow, column: lastLineLen };
 
-    this._edit(snap, rangeStart, rangeEnd, indented.join("\n"));
+    if (!this._edit(snap, rangeStart, rangeEnd, indented.join("\n"))) return;
 
     // Place cursor at its shifted position
     const cursor = this.cursor;
@@ -851,7 +851,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
       }
     }
 
-    this._edit(snap, rangeStart, rangeEnd, dedented.join("\n"));
+    if (!this._edit(snap, rangeStart, rangeEnd, dedented.join("\n"))) return;
 
     // Adjust cursor column
     const newCol = Math.max(0, cursor.column - spacesRemovedOnCursorLine);
@@ -883,7 +883,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
     if (this._selection && !isCollapsed(snap, this._selection)) {
       const range = resolveAnchorRange(snap, this._selection.range);
       if (range) {
-        this._edit(snap, range.start, range.end, "");
+        if (!this._edit(snap, range.start, range.end, "")) return;
         this._cursor = range.start;
         this._selection = selectionAtPoint(this.multiBuffer, range.start);
       }
@@ -917,15 +917,21 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
    * Handles cross-excerpt ranges by splitting into per-excerpt edits
    * applied bottom-to-top so that row numbers for higher excerpts
    * aren't shifted during processing.
+   *
+   * Returns false if the edit was rejected (e.g. targeting a non-editable excerpt).
    */
   private _edit(
     snap: MultiBufferSnapshot,
     start: MultiBufferPoint,
     end: MultiBufferPoint,
     newText: string,
-  ): void {
+  ): boolean {
     const startBuf = snap.toBufferPoint(start);
     const endBuf = snap.toBufferPoint(end);
+
+    // Reject edits that touch non-editable excerpts
+    if (startBuf && !startBuf.excerpt.editable) return false;
+    if (endBuf && !endBuf.excerpt.editable) return false;
 
     // Same excerpt (or same point) — single edit
     if (
@@ -944,7 +950,14 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
       }
       this._redoStack = [];
       this.multiBuffer.edit(start, end, newText);
-      return;
+      return true;
+    }
+
+    // Cross-excerpt: reject if any spanned excerpt is non-editable
+    for (const exc of snap.excerpts) {
+      if (exc.startRow >= startBuf.excerpt.startRow && exc.startRow <= endBuf.excerpt.startRow) {
+        if (!exc.editable) return false;
+      }
     }
 
     // Cross-excerpt: split into per-excerpt edits, applied bottom-to-top
@@ -972,6 +985,7 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
       this._undoStack.shift();
     }
     this._redoStack = [];
+    return true;
   }
 
   /**

--- a/src/multibuffer/excerpt.ts
+++ b/src/multibuffer/excerpt.ts
@@ -90,6 +90,7 @@ export function createExcerpt(
   buffer: BufferSnapshot,
   range: ExcerptRange,
   hasTrailingNewline: boolean,
+  editable = true,
 ): Excerpt {
   const endRow = range.context.end.row;
   if (endRow > buffer.lineCount) {
@@ -104,6 +105,7 @@ export function createExcerpt(
     buffer,
     range,
     hasTrailingNewline,
+    editable,
     textSummary: computeExcerptSummary(buffer, range),
   };
 }
@@ -126,6 +128,7 @@ export function toExcerptInfo(
     startRow,
     endRow,
     hasTrailingNewline: excerpt.hasTrailingNewline,
+    editable: excerpt.editable,
   };
 }
 

--- a/src/multibuffer/multibuffer.ts
+++ b/src/multibuffer/multibuffer.ts
@@ -488,17 +488,18 @@ class MultiBufferImpl implements MultiBuffer {
   addExcerpt(
     buffer: Buffer,
     range: ExcerptRange,
-    options?: { hasTrailingNewline?: boolean },
+    options?: { hasTrailingNewline?: boolean; editable?: boolean },
   ): ExcerptId {
     // biome-ignore lint/plugin/no-type-assertion: expect: BufferId is branded string, Map key is string
     this._buffers.set(buffer.id as string, buffer);
     const snapshot = buffer.snapshot();
     const hasTrailing = options?.hasTrailingNewline ?? false;
+    const editable = options?.editable ?? true;
     // Insert a placeholder to allocate the slot and get the key.
     // biome-ignore lint/plugin/no-type-assertion: expect: SlotMap placeholder insert requires cast; immediately overwritten via set()
     const id = this._excerpts.insert(undefined as unknown as Excerpt) as unknown as ExcerptId;
     // Build the excerpt with its own ID, then set the real value.
-    const excerpt = createExcerpt(id, snapshot, range, hasTrailing);
+    const excerpt = createExcerpt(id, snapshot, range, hasTrailing, editable);
     this._excerpts.set(id, excerpt);
     this._order.push(id);
     this._rebuildCache();
@@ -600,6 +601,7 @@ class MultiBufferImpl implements MultiBuffer {
       snapshot,
       newRange,
       oldExcerpt.hasTrailingNewline,
+      oldExcerpt.editable,
     );
     this._excerpts.set(excerptId, newExcerpt);
     this._rebuildCache();
@@ -725,7 +727,7 @@ class MultiBufferImpl implements MultiBuffer {
         primary: exc.range.primary,
       };
 
-      const refreshed = createExcerpt(id, newSnap, clampedRange, exc.hasTrailingNewline);
+      const refreshed = createExcerpt(id, newSnap, clampedRange, exc.hasTrailingNewline, exc.editable);
       this._excerpts.set(id, refreshed);
     }
 

--- a/src/multibuffer/types.ts
+++ b/src/multibuffer/types.ts
@@ -106,6 +106,7 @@ export interface Excerpt {
   readonly buffer: BufferSnapshot;
   readonly range: ExcerptRange;
   readonly hasTrailingNewline: boolean;
+  readonly editable: boolean;
   readonly textSummary: TextSummary;
 }
 
@@ -119,6 +120,7 @@ export interface ExcerptInfo {
   readonly startRow: MultiBufferRow;
   readonly endRow: MultiBufferRow;
   readonly hasTrailingNewline: boolean;
+  readonly editable: boolean;
 }
 
 /**
@@ -166,7 +168,7 @@ export interface MultiBuffer {
   addExcerpt(
     buffer: import("../buffer/types.ts").Buffer,
     range: ExcerptRange,
-    options?: { hasTrailingNewline?: boolean },
+    options?: { hasTrailingNewline?: boolean; editable?: boolean },
   ): ExcerptId;
   removeExcerpt(excerptId: ExcerptId): void;
   setExcerptsForBuffer(

--- a/tests/editor/non-editable.test.ts
+++ b/tests/editor/non-editable.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for non-editable excerpt behavior.
+ *
+ * When an excerpt has editable: false, the editor should:
+ * - Reject all text mutations targeting that excerpt
+ * - Allow cursor movement through non-editable excerpts
+ * - Allow selection across non-editable excerpts
+ * - Allow copy from non-editable excerpts
+ * - Reject cut/delete/paste that touch non-editable excerpts
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createBuffer } from "../../src/buffer/buffer.ts";
+import type { BufferId, BufferRow } from "../../src/buffer/types.ts";
+import { Editor } from "../../src/editor/editor.ts";
+import { createMultiBuffer } from "../../src/multibuffer/multibuffer.ts";
+import type { MultiBufferRow } from "../../src/multibuffer/types.ts";
+
+// biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in tests
+const bid = (s: string) => s as BufferId;
+// biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in tests
+const mbRow = (n: number) => n as MultiBufferRow;
+// biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in tests
+const bRow = (n: number) => n as BufferRow;
+
+function range(startRow: number, endRow: number) {
+  const context = {
+    start: { row: bRow(startRow), column: 0 },
+    end: { row: bRow(endRow), column: 0 },
+  };
+  return { context, primary: context };
+}
+
+describe("Non-editable excerpts", () => {
+  test("editable defaults to true", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2));
+    const info = mb.excerpts[0];
+    if (!info) throw new Error("expected excerpt");
+    expect(info.editable).toBe(true);
+  });
+
+  test("editable: false is stored on excerpt", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const info = mb.excerpts[0];
+    if (!info) throw new Error("expected excerpt");
+    expect(info.editable).toBe(false);
+  });
+
+  test("insertText rejected in non-editable excerpt", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const editor = new Editor(mb);
+
+    editor.setCursor({ row: mbRow(0), column: 2 });
+    editor.dispatch({ type: "insertText", text: "X" });
+
+    // Text should be unchanged
+    const lines = mb.snapshot().lines(mbRow(0), mbRow(2));
+    expect(lines[0]).toBe("hello");
+    expect(lines[1]).toBe("world");
+  });
+
+  test("insertNewline rejected in non-editable excerpt", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const editor = new Editor(mb);
+
+    editor.setCursor({ row: mbRow(0), column: 2 });
+    editor.dispatch({ type: "insertNewline" });
+
+    expect(mb.lineCount).toBe(2);
+  });
+
+  test("deleteBackward rejected in non-editable excerpt", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const editor = new Editor(mb);
+
+    editor.setCursor({ row: mbRow(0), column: 3 });
+    editor.dispatch({ type: "deleteBackward", granularity: "character" });
+
+    const lines = mb.snapshot().lines(mbRow(0), mbRow(1));
+    expect(lines[0]).toBe("hello");
+  });
+
+  test("deleteForward rejected in non-editable excerpt", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const editor = new Editor(mb);
+
+    editor.setCursor({ row: mbRow(0), column: 3 });
+    editor.dispatch({ type: "deleteForward", granularity: "character" });
+
+    const lines = mb.snapshot().lines(mbRow(0), mbRow(1));
+    expect(lines[0]).toBe("hello");
+  });
+
+  test("deleteLine rejected in non-editable excerpt", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const editor = new Editor(mb);
+
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "deleteLine" });
+
+    expect(mb.lineCount).toBe(2);
+  });
+
+  test("cut rejected in non-editable excerpt", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const editor = new Editor(mb);
+
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "cut" });
+
+    expect(mb.lineCount).toBe(2);
+  });
+
+  test("cursor movement works through non-editable excerpts", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const editor = new Editor(mb);
+
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "moveCursor", direction: "right", granularity: "character" });
+    expect(editor.cursor.column).toBe(1);
+
+    editor.dispatch({ type: "moveCursor", direction: "down", granularity: "line" });
+    expect(editor.cursor.row).toBe(mbRow(1));
+  });
+
+  test("selection works across non-editable excerpts", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const editor = new Editor(mb);
+
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "selectAll" });
+
+    const text = editor.getSelectedText();
+    expect(text).toBe("hello\nworld");
+  });
+
+  test("copy works from non-editable excerpt", () => {
+    const buf = createBuffer(bid("a.ts"), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, range(0, 2), { editable: false });
+    const editor = new Editor(mb);
+
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "selectAll" });
+
+    // copy is a no-op in the editor (clipboard handled externally),
+    // but getSelectedText should still work
+    expect(editor.getSelectedText()).toBe("hello\nworld");
+    editor.dispatch({ type: "copy" });
+    // Text unchanged after copy
+    expect(mb.snapshot().lines(mbRow(0), mbRow(2))[0]).toBe("hello");
+  });
+});
+
+describe("Mixed editable and non-editable excerpts", () => {
+  function createMixedEditor() {
+    const oldBuf = createBuffer(bid("old.ts"), "deleted line");
+    const newBuf = createBuffer(bid("new.ts"), "inserted line");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(oldBuf, range(0, 1), { editable: false, hasTrailingNewline: false });
+    mb.addExcerpt(newBuf, range(0, 1), { editable: true, hasTrailingNewline: false });
+    const editor = new Editor(mb);
+    return { oldBuf, newBuf, mb, editor };
+  }
+
+  test("edit in editable excerpt succeeds", () => {
+    const { mb, editor } = createMixedEditor();
+    // Row 0 = non-editable "deleted line", Row 1 = editable "inserted line"
+    editor.setCursor({ row: mbRow(1), column: 0 });
+    editor.dispatch({ type: "insertText", text: "X" });
+
+    const lines = mb.snapshot().lines(mbRow(0), mbRow(2));
+    expect(lines[0]).toBe("deleted line");
+    expect(lines[1]).toBe("Xinserted line");
+  });
+
+  test("edit in non-editable excerpt rejected", () => {
+    const { mb, editor } = createMixedEditor();
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "insertText", text: "X" });
+
+    const lines = mb.snapshot().lines(mbRow(0), mbRow(2));
+    expect(lines[0]).toBe("deleted line");
+    expect(lines[1]).toBe("inserted line");
+  });
+
+  test("backspace at start of editable into non-editable is rejected", () => {
+    const { mb, editor } = createMixedEditor();
+    // Cursor at start of editable excerpt (row 1, col 0)
+    // Backspace would try to delete into non-editable row 0
+    editor.setCursor({ row: mbRow(1), column: 0 });
+    editor.dispatch({ type: "deleteBackward", granularity: "character" });
+
+    // Both lines unchanged
+    expect(mb.lineCount).toBe(2);
+    const lines = mb.snapshot().lines(mbRow(0), mbRow(2));
+    expect(lines[0]).toBe("deleted line");
+    expect(lines[1]).toBe("inserted line");
+  });
+
+  test("delete at end of non-editable into editable is rejected", () => {
+    const { mb, editor } = createMixedEditor();
+    // Cursor at end of non-editable excerpt
+    editor.setCursor({ row: mbRow(0), column: 12 });
+    editor.dispatch({ type: "deleteForward", granularity: "character" });
+
+    expect(mb.lineCount).toBe(2);
+  });
+
+  test("cursor moves freely between editable and non-editable", () => {
+    const { editor } = createMixedEditor();
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "moveCursor", direction: "down", granularity: "line" });
+    expect(editor.cursor.row).toBe(mbRow(1));
+
+    editor.dispatch({ type: "moveCursor", direction: "up", granularity: "line" });
+    expect(editor.cursor.row).toBe(mbRow(0));
+  });
+
+  test("selection spans both editable and non-editable", () => {
+    const { editor } = createMixedEditor();
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "selectAll" });
+    expect(editor.getSelectedText()).toBe("deleted line\ninserted line");
+  });
+
+  test("cut with selection spanning non-editable is rejected", () => {
+    const { mb, editor } = createMixedEditor();
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "selectAll" });
+    editor.dispatch({ type: "cut" });
+
+    // Nothing should be deleted
+    expect(mb.lineCount).toBe(2);
+  });
+
+  test("paste over selection spanning non-editable is rejected", () => {
+    const { mb, editor } = createMixedEditor();
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "selectAll" });
+    editor.dispatch({ type: "paste", text: "replacement" });
+
+    // Nothing should change
+    expect(mb.lineCount).toBe(2);
+    const lines = mb.snapshot().lines(mbRow(0), mbRow(2));
+    expect(lines[0]).toBe("deleted line");
+  });
+
+  test("editable flag preserved after buffer edit", () => {
+    const { mb, editor } = createMixedEditor();
+    // Edit in the editable excerpt
+    editor.setCursor({ row: mbRow(1), column: 0 });
+    editor.dispatch({ type: "insertText", text: "Z" });
+
+    // Both excerpts should retain their editable flags
+    const excerpts = mb.excerpts;
+    expect(excerpts[0]?.editable).toBe(false);
+    expect(excerpts[1]?.editable).toBe(true);
+  });
+
+  test("undo works within editable excerpt", () => {
+    const { mb, editor } = createMixedEditor();
+    editor.setCursor({ row: mbRow(1), column: 0 });
+    editor.dispatch({ type: "insertText", text: "Z" });
+
+    let lines = mb.snapshot().lines(mbRow(1), mbRow(2));
+    expect(lines[0]).toBe("Zinserted line");
+
+    editor.dispatch({ type: "undo" });
+    lines = mb.snapshot().lines(mbRow(1), mbRow(2));
+    expect(lines[0]).toBe("inserted line");
+  });
+});
+
+describe("Non-editable with trailing newline excerpts", () => {
+  test("editable flag preserved through trailing newline boundary", () => {
+    const oldBuf = createBuffer(bid("old.ts"), "old line 1\nold line 2");
+    const newBuf = createBuffer(bid("new.ts"), "new line 1");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(oldBuf, range(0, 2), { editable: false, hasTrailingNewline: true });
+    mb.addExcerpt(newBuf, range(0, 1), { editable: true });
+
+    // row 0: "old line 1" (non-editable)
+    // row 1: "old line 2" (non-editable)
+    // row 2: "" (trailing newline, non-editable)
+    // row 3: "new line 1" (editable)
+
+    const editor = new Editor(mb);
+
+    // Can't edit in the non-editable excerpt
+    editor.setCursor({ row: mbRow(0), column: 0 });
+    editor.dispatch({ type: "insertText", text: "X" });
+    expect(mb.snapshot().lines(mbRow(0), mbRow(1))[0]).toBe("old line 1");
+
+    // Can edit in the editable excerpt
+    editor.setCursor({ row: mbRow(3), column: 0 });
+    editor.dispatch({ type: "insertText", text: "Y" });
+    expect(mb.snapshot().lines(mbRow(3), mbRow(4))[0]).toBe("Ynew line 1");
+  });
+});

--- a/tests/multibuffer/excerpt.test.ts
+++ b/tests/multibuffer/excerpt.test.ts
@@ -84,6 +84,7 @@ describe("ExcerptInfo", () => {
       startRow: mbRow(0),
       endRow: mbRow(10),
       hasTrailingNewline: false,
+      editable: true,
     };
 
     const lineCount = num(info.endRow) - num(info.startRow);
@@ -98,6 +99,7 @@ describe("ExcerptInfo", () => {
       startRow: mbRow(0),
       endRow: mbRow(5),
       hasTrailingNewline: false,
+      editable: true,
     };
 
     const excerpt2: ExcerptInfo = {
@@ -107,6 +109,7 @@ describe("ExcerptInfo", () => {
       startRow: mbRow(5),
       endRow: mbRow(15),
       hasTrailingNewline: false,
+      editable: true,
     };
 
     expect(num(excerpt2.startRow)).toBe(num(excerpt1.endRow));
@@ -134,6 +137,7 @@ describe("Empty Excerpt Edge Cases", () => {
       startRow: mbRow(10),
       endRow: mbRow(10), // Same - zero lines
       hasTrailingNewline: false,
+      editable: true,
     };
 
     const lineCount = num(info.endRow) - num(info.startRow);
@@ -189,6 +193,7 @@ describe("Trailing Newline Handling", () => {
       startRow: mbRow(0),
       endRow: mbRow(5),
       hasTrailingNewline: false,
+      editable: true,
     };
 
     const withNewline: ExcerptInfo = {
@@ -198,6 +203,7 @@ describe("Trailing Newline Handling", () => {
       startRow: mbRow(0),
       endRow: mbRow(6), // One extra line for trailing newline
       hasTrailingNewline: true,
+      editable: true,
     };
 
     expect(num(withNewline.endRow) - num(withoutNewline.endRow)).toBe(1);


### PR DESCRIPTION
Closes #113

## Summary
- Adds `editable` flag to excerpts (default: `true`). When `false`, the editor rejects all text mutations targeting that excerpt while still allowing cursor movement, selection, and copy.
- Guards edits in `Editor._edit()` — if start, end, or any spanned excerpt is non-editable, the edit is silently rejected and cursor/selection remain unchanged.
- Preserves `editable` flag through `expandExcerpt` and `_refreshExcerptsForBuffer` (buffer edits don't lose the flag).

## Test plan
- [x] 22 new tests in `tests/editor/non-editable.test.ts`
  - Insert/delete/newline/cut rejected in non-editable excerpts
  - Cursor movement works through non-editable excerpts
  - Selection and copy work across non-editable excerpts
  - Mixed editable/non-editable: edits succeed in editable, fail in non-editable
  - Boundary edits: backspace from editable into non-editable, delete from non-editable into editable
  - Cross-excerpt operations (cut, paste) spanning non-editable rejected
  - Undo works within editable excerpts
  - Trailing newline boundary preserves editability
- [x] All 764 tests pass, 0 fail
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)