### PR TITLE
feat: implement line decoration rendering in DomRenderer

### DIFF
--- a/src/renderer/dom.ts
+++ b/src/renderer/dom.ts
@@ -13,7 +13,7 @@ import {
   createViewport,
   yToVisualRow,
 } from "./measurement.ts";
-import type { Measurements, Renderer, RenderState, ScrollTarget, Viewport } from "./types.ts";
+import type { Decoration, DecorationStyle, Measurements, Renderer, RenderState, ScrollTarget, Viewport } from "./types.ts";
 import { charColToVisualCol, visualColToCharCol, visualWidth, WrapMap, wrapLine } from "./wrap-map.ts";
 
 /** Slice tokens to a column range, adjusting offsets to be segment-relative. */
@@ -51,6 +51,7 @@ export class DomRenderer implements Renderer {
   private _snapshot: MultiBufferSnapshot | null = null;
   private _wrapMap: WrapMap | null = null;
   private _highlighter: SyntaxHighlighter | null = null;
+  private _decorations: readonly Decoration[] = [];
   private _onScroll: (() => void) | null = null;
   private _onClick: ((e: MouseEvent) => void) | null = null;
   private _onMouseMove: ((e: MouseEvent) => void) | null = null;
@@ -157,6 +158,7 @@ export class DomRenderer implements Renderer {
     this._rowPool = [];
     this._snapshot = null;
     this._wrapMap = null;
+    this._decorations = [];
     this._onScroll = null;
     this._onClick = null;
   }
@@ -181,8 +183,9 @@ export class DomRenderer implements Renderer {
   render(state: RenderState, lines: readonly string[]): void {
     if (!this._linesContainer || !this._spacer || !this._scrollContainer) return;
 
-    const { viewport, excerptHeaders } = state;
+    const { viewport, excerptHeaders, decorations } = state;
     this._viewport = viewport;
+    this._decorations = decorations;
 
     // Update spacer height
     const totalLines = this._snapshot?.lineCount ?? viewport.endRow;
@@ -199,6 +202,17 @@ export class DomRenderer implements Renderer {
       headerMap.set(header.row, header);
     }
 
+    // Build decoration lookup: mbRow → decoration style (last decoration wins)
+    const decorationMap = new Map<number, Partial<DecorationStyle>>();
+    for (const dec of decorations) {
+      if (!dec.style) continue;
+      for (let r = dec.range.start.row; r <= dec.range.end.row; r++) {
+        if (r >= viewport.startRow && r < viewport.endRow) {
+          decorationMap.set(r, dec.style);
+        }
+      }
+    }
+
     // Determine the wrap width
     const wrapWidth = this._measurements.wrapWidth ?? 0;
 
@@ -212,6 +226,7 @@ export class DomRenderer implements Renderer {
       headerLabel?: string;
       tokens?: Token[];
       gutterText: string;
+      decoration?: Partial<DecorationStyle>;
     }> = [];
 
     for (let i = 0; i < lines.length; i++) {
@@ -239,6 +254,8 @@ export class DomRenderer implements Renderer {
       const showLineNumber = !header && bufferRow >= 0;
       const gutterBase = showLineNumber ? String(bufferRow + 1) : "";
 
+      const decoration = decorationMap.get(mbRow);
+
       if (wrapWidth > 0) {
         const segments = wrapLine(lineText, wrapWidth);
         let charOffset = 0;
@@ -260,6 +277,7 @@ export class DomRenderer implements Renderer {
             headerLabel: header?.label,
             tokens: segTokens,
             gutterText: s === 0 ? gutterBase : "",
+            decoration,
           });
         }
       } else {
@@ -272,6 +290,7 @@ export class DomRenderer implements Renderer {
           headerLabel: header?.label,
           tokens: lineTokens,
           gutterText: gutterBase,
+          decoration,
         });
       }
     }
@@ -299,7 +318,7 @@ export class DomRenderer implements Renderer {
       if (vr.isHeader && vr.headerPath) {
         this._renderAsHeader(rowEl, vr.headerPath, vr.headerLabel);
       } else {
-        this._renderAsLine(rowEl, vr.gutterText, vr.text, vr.tokens);
+        this._renderAsLine(rowEl, vr.gutterText, vr.text, vr.tokens, vr.decoration);
       }
     }
   }
@@ -396,7 +415,7 @@ export class DomRenderer implements Renderer {
       {
         viewport,
         selections: [],
-        decorations: [],
+        decorations: this._decorations,
         excerptHeaders,
         focused: false,
       },
@@ -453,15 +472,35 @@ export class DomRenderer implements Renderer {
     gutterText: string,
     text: string,
     tokens?: Token[],
+    decoration?: Partial<DecorationStyle>,
   ): void {
     rowEl.root.style.display = "flex";
-    rowEl.root.style.background = "var(--editor-line-bg, transparent)";
     rowEl.root.style.borderTop = "";
-    rowEl.gutter.textContent = gutterText;
-    rowEl.gutter.style.background = "var(--editor-line-bg, transparent)";
-    rowEl.content.style.color = "";
-    rowEl.content.style.fontWeight = "";
+
+    // Apply decoration styles or defaults
+    const bg = decoration?.backgroundColor ?? "var(--editor-line-bg, transparent)";
+    rowEl.root.style.background = bg;
+    rowEl.gutter.style.background = decoration?.gutterBackground ?? bg;
+    rowEl.gutter.style.color = decoration?.gutterColor ?? "";
+    rowEl.content.style.color = decoration?.color ?? "";
+    rowEl.content.style.fontWeight = decoration?.fontWeight ?? "";
+    rowEl.content.style.fontStyle = decoration?.fontStyle ?? "";
+    rowEl.content.style.textDecoration = decoration?.textDecoration ?? "";
     rowEl.content.style.fontSize = "";
+
+    // Gutter text: sign character prepended if present
+    if (decoration?.gutterSign) {
+      rowEl.gutter.textContent = "";
+      const numSpan = document.createElement("span");
+      numSpan.textContent = gutterText;
+      const signSpan = document.createElement("span");
+      signSpan.textContent = ` ${decoration.gutterSign} `;
+      signSpan.style.color = decoration.gutterSignColor ?? "";
+      rowEl.gutter.appendChild(numSpan);
+      rowEl.gutter.appendChild(signSpan);
+    } else {
+      rowEl.gutter.textContent = gutterText;
+    }
 
     if (tokens && tokens.length > 0) {
       buildHighlightedSpans(rowEl.content, text, tokens);

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -69,6 +69,14 @@ export interface DecorationStyle {
   readonly fontWeight: "normal" | "bold";
   readonly fontStyle: "normal" | "italic";
   readonly textDecoration: "none" | "underline" | "line-through";
+  /** Background color for the gutter area on decorated lines */
+  readonly gutterBackground: string;
+  /** Text color for the gutter line number on decorated lines */
+  readonly gutterColor: string;
+  /** A sign character rendered between gutter and content (e.g., "+", "−") */
+  readonly gutterSign: string;
+  /** Color for the gutter sign character */
+  readonly gutterSignColor: string;
 }
 
 /**

--- a/tests/renderer/decoration.test.ts
+++ b/tests/renderer/decoration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for decoration types and mapping logic.
+ *
+ * The actual DOM rendering of decorations is tested via Playwright (e2e).
+ * These tests verify the decoration data model and row-range expansion.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { MultiBufferRow } from "../../src/multibuffer/types.ts";
+import type { Decoration, DecorationStyle } from "../../src/renderer/types.ts";
+
+// biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in tests
+const mbRow = (n: number) => n as MultiBufferRow;
+
+/** Simulate the decoration-to-row mapping logic used in DomRenderer.render() */
+function buildDecorationMap(
+  decorations: readonly Decoration[],
+  startRow: number,
+  endRow: number,
+): Map<number, Partial<DecorationStyle>> {
+  const map = new Map<number, Partial<DecorationStyle>>();
+  for (const dec of decorations) {
+    if (!dec.style) continue;
+    for (let r = dec.range.start.row; r <= dec.range.end.row; r++) {
+      if (r >= startRow && r < endRow) {
+        map.set(r, dec.style);
+      }
+    }
+  }
+  return map;
+}
+
+describe("Decoration row mapping", () => {
+  test("single-line decoration maps to one row", () => {
+    const dec: Decoration = {
+      range: {
+        start: { row: mbRow(5), column: 0 },
+        end: { row: mbRow(5), column: 10 },
+      },
+      style: { backgroundColor: "red" },
+    };
+
+    const map = buildDecorationMap([dec], 0, 20);
+    expect(map.size).toBe(1);
+    expect(map.get(5)?.backgroundColor).toBe("red");
+  });
+
+  test("multi-line decoration maps to all rows in range", () => {
+    const dec: Decoration = {
+      range: {
+        start: { row: mbRow(3), column: 0 },
+        end: { row: mbRow(7), column: 0 },
+      },
+      style: { backgroundColor: "green" },
+    };
+
+    const map = buildDecorationMap([dec], 0, 20);
+    expect(map.size).toBe(5); // rows 3, 4, 5, 6, 7
+    for (let r = 3; r <= 7; r++) {
+      expect(map.get(r)?.backgroundColor).toBe("green");
+    }
+  });
+
+  test("decorations outside viewport are excluded", () => {
+    const dec: Decoration = {
+      range: {
+        start: { row: mbRow(0), column: 0 },
+        end: { row: mbRow(2), column: 0 },
+      },
+      style: { backgroundColor: "blue" },
+    };
+
+    const map = buildDecorationMap([dec], 5, 15);
+    expect(map.size).toBe(0);
+  });
+
+  test("decoration partially overlapping viewport is clipped", () => {
+    const dec: Decoration = {
+      range: {
+        start: { row: mbRow(3), column: 0 },
+        end: { row: mbRow(8), column: 0 },
+      },
+      style: { backgroundColor: "yellow" },
+    };
+
+    // Viewport is rows 5-10
+    const map = buildDecorationMap([dec], 5, 10);
+    expect(map.size).toBe(4); // rows 5, 6, 7, 8
+    expect(map.has(3)).toBe(false);
+    expect(map.has(4)).toBe(false);
+    expect(map.get(5)?.backgroundColor).toBe("yellow");
+    expect(map.get(8)?.backgroundColor).toBe("yellow");
+  });
+
+  test("overlapping decorations: last wins", () => {
+    const dec1: Decoration = {
+      range: {
+        start: { row: mbRow(0), column: 0 },
+        end: { row: mbRow(5), column: 0 },
+      },
+      style: { backgroundColor: "red" },
+    };
+    const dec2: Decoration = {
+      range: {
+        start: { row: mbRow(3), column: 0 },
+        end: { row: mbRow(8), column: 0 },
+      },
+      style: { backgroundColor: "green" },
+    };
+
+    const map = buildDecorationMap([dec1, dec2], 0, 10);
+    // Rows 0-2: red only
+    expect(map.get(0)?.backgroundColor).toBe("red");
+    expect(map.get(2)?.backgroundColor).toBe("red");
+    // Rows 3-5: green wins (last decoration)
+    expect(map.get(3)?.backgroundColor).toBe("green");
+    expect(map.get(5)?.backgroundColor).toBe("green");
+    // Rows 6-8: green only
+    expect(map.get(7)?.backgroundColor).toBe("green");
+  });
+
+  test("decoration without style is skipped", () => {
+    const dec: Decoration = {
+      range: {
+        start: { row: mbRow(0), column: 0 },
+        end: { row: mbRow(5), column: 0 },
+      },
+    };
+
+    const map = buildDecorationMap([dec], 0, 10);
+    expect(map.size).toBe(0);
+  });
+
+  test("gutter fields are passed through", () => {
+    const dec: Decoration = {
+      range: {
+        start: { row: mbRow(2), column: 0 },
+        end: { row: mbRow(2), column: 0 },
+      },
+      style: {
+        backgroundColor: "rgba(204, 36, 29, 0.15)",
+        gutterBackground: "rgba(204, 36, 29, 0.25)",
+        gutterSign: "\u2212",
+        gutterSignColor: "#cc241d",
+      },
+    };
+
+    const map = buildDecorationMap([dec], 0, 10);
+    const style = map.get(2);
+    expect(style?.gutterSign).toBe("\u2212");
+    expect(style?.gutterSignColor).toBe("#cc241d");
+    expect(style?.gutterBackground).toBe("rgba(204, 36, 29, 0.25)");
+  });
+});
+
+describe("DecorationStyle type contract", () => {
+  test("all style fields are optional via Partial", () => {
+    // This is a compile-time check — if it compiles, the contract is correct
+    const style: Partial<DecorationStyle> = {};
+    expect(style.backgroundColor).toBeUndefined();
+    expect(style.gutterSign).toBeUndefined();
+  });
+
+  test("full style can be constructed", () => {
+    const style: DecorationStyle = {
+      backgroundColor: "#ff0000",
+      color: "#ffffff",
+      borderColor: "#000000",
+      fontWeight: "bold",
+      fontStyle: "italic",
+      textDecoration: "underline",
+      gutterBackground: "#330000",
+      gutterColor: "#ff6666",
+      gutterSign: "+",
+      gutterSignColor: "#00ff00",
+    };
+    expect(style.gutterSign).toBe("+");
+    expect(style.fontWeight).toBe("bold");
+  });
+});


### PR DESCRIPTION
Closes #114

## Summary
- Extends `DecorationStyle` with gutter-specific fields: `gutterBackground`, `gutterColor`, `gutterSign`, `gutterSignColor`
- Implements decoration application in `DomRenderer.render()` — builds a row→decoration map and applies styles per-line
- Decoration styles control: line background, text color, font weight/style/decoration, gutter background, and a sign character (e.g., "+"/"\u2212") between line number and content
- Caches decorations so scroll-triggered re-renders preserve them
- Overlapping decorations use last-wins semantics

## Test plan
- [x] 9 new tests in `tests/renderer/decoration.test.ts`
  - Single/multi-line decoration mapping
  - Viewport clipping (outside, partially overlapping)
  - Overlapping decorations: last wins
  - Decorations without style are skipped
  - Gutter fields passed through correctly
  - Type contract verification
- [x] All 773 tests pass, 0 fail
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build:playground` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)