### PR TITLE
fix(bench): revert to single run (5-run was hanging)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,34 +21,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run benchmarks (5 runs, take best)
-        run: |
-          for i in 1 2 3 4 5; do
-            echo "Run $i/5..."
-            bun run bench --json > "bench-run-$i.json"
-          done
-
-          # Merge runs: for each benchmark, take the minimum avgMs (best of 5)
-          jq -s '
-            # Flatten all suites from all runs
-            [.[]] |
-            # Group by suite name
-            group_by(.[0].suite) |
-            map(
-              # For each suite group, get suite name and merge results
-              {
-                suite: .[0][0].suite,
-                results: (
-                  # Flatten all results from this suite across runs
-                  [.[][] | .results[]] |
-                  # Group by benchmark name
-                  group_by(.name) |
-                  # For each benchmark, take the run with minimum avgMs
-                  map(min_by(.avgMs))
-                )
-              }
-            )
-          ' bench-run-*.json > bench-results.json
+      - name: Run benchmarks
+        run: bun run bench --json > bench-results.json
 
       - name: Push results to bench-data branch
         run: |
@@ -63,12 +37,12 @@ jobs:
             git rm -rf .
             echo "# Benchmark History" > README.md
             echo "" >> README.md
-            echo "This branch stores benchmark results (best of 5 runs per commit)." >> README.md
+            echo "This branch stores benchmark results." >> README.md
             echo "" >> README.md
             echo "Each line in history.jsonl is a JSON object with:" >> README.md
             echo "- \`sha\`: commit hash" >> README.md
             echo "- \`timestamp\`: ISO timestamp" >> README.md
-            echo "- \`suites\`: array of benchmark suite results (best avgMs from 5 runs)" >> README.md
+            echo "- \`suites\`: array of benchmark suite results" >> README.md
             git add README.md
           fi
 


### PR DESCRIPTION
Reverts to single benchmark run. The 5-run best-of approach was causing CI to hang for 40+ minutes.