### PR TITLE
fix(bench): add iterations to diff benchmarks

### DIFF
--- a/benchmarks/diff.bench.ts
+++ b/benchmarks/diff.bench.ts
@@ -76,54 +76,70 @@ export const diffBenchmarks: BenchmarkSuite = {
       fn() {
         diff(small100, small100Modified);
       },
+      iterations: 1000,
     },
     {
       name: "diff - 1K lines, scattered edits",
       fn() {
         diff(medium1k, medium1kScattered);
       },
+      iterations: 100,
+      targetMs: 5,
     },
     {
       name: "diff - 1K lines, insertions",
       fn() {
         diff(medium1k, medium1kInserted);
       },
+      iterations: 100,
+      targetMs: 5,
     },
     {
       name: "diff - 1K lines, deletions",
       fn() {
         diff(medium1k, medium1kDeleted);
       },
+      iterations: 100,
+      targetMs: 5,
     },
     {
       name: "diff - 10K lines, few changes",
       fn() {
         diff(large10k, large10kFewChanges);
       },
+      iterations: 20,
+      targetMs: 50,
     },
     {
       name: "diff - 1K lines, full rewrite (worst case)",
       fn() {
         diff(medium1k, medium1kRewrite);
       },
+      iterations: 10,
+      targetMs: 50,
     },
     {
       name: "diff - identical 1K lines (best case)",
       fn() {
         diff(medium1k, medium1k);
       },
+      iterations: 100,
     },
     {
       name: "unified diff - 1K lines, scattered edits",
       fn() {
         createUnifiedDiff(oldId, medium1k, newId, medium1kScattered);
       },
+      iterations: 100,
+      targetMs: 10,
     },
     {
       name: "unified diff - 10K lines, few changes",
       fn() {
         createUnifiedDiff(oldId, large10k, newId, large10kFewChanges);
       },
+      iterations: 20,
+      targetMs: 50,
     },
     {
       name: "createUnifiedDiffMultiBuffer - 1K lines, scattered edits",


### PR DESCRIPTION
## Summary

Add explicit iteration counts to the diff benchmarks that were causing CI to hang.

## Root cause

The diff benchmarks I added were missing `iterations` fields, causing them to default to 1000 iterations. For O(N*D) operations like:
- `diff - 10K lines, few changes` 
- `diff - 1K lines, full rewrite (worst case)`

...this caused CI to hang for 40+ minutes.

## Fix

Add explicit iteration counts appropriate for each benchmark's complexity:
- Small diffs (100 lines): 1000 iterations
- Medium diffs (1K lines): 100 iterations  
- Large diffs (10K lines): 20 iterations
- Full rewrite (worst case): 10 iterations

## Note

There's a separate issue with editor benchmarks added in PR #130 (by the Perf Improver bot) that also cause hangs. Those should be fixed separately as they grow the buffer with each iteration.

## Test plan

- [x] Diff benchmarks complete in ~300ms locally
- [x] All diff benchmarks pass