### PR TITLE
fix(editor): allow cross-excerpt edits within same buffer

### DIFF
--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -972,7 +972,23 @@ private _moveLine(snap: MultiBufferSnapshot, direction: "up" | "down"): void {
       }
     }
 
-    // Cross-excerpt: split into per-excerpt edits, applied bottom-to-top
+    // Cross-excerpt within same buffer: edit directly (handles boundary newlines)
+    if (startBuf.excerpt.bufferId === endBuf.excerpt.bufferId) {
+      const removedText = knownRemovedText ?? this._getTextInRange(snap, start, end);
+      this._undoStack.push({
+        edits: [{ editStart: start, removedText, insertedText: newText }],
+        cursorBefore: this._cursor,
+        selectionBefore: this._selection,
+      });
+      if (this._undoStack.length > Editor._MAX_HISTORY) {
+        this._undoStack.shift();
+      }
+      this._redoStack = [];
+      this.multiBuffer.edit(start, end, newText);
+      return true;
+    }
+
+    // Cross-excerpt across different buffers: split into per-excerpt edits, applied bottom-to-top
     const subEdits = this._splitCrossExcerptRange(snap, start, end, startBuf.excerpt, endBuf.excerpt, newText);
     const editOps: EditOp[] = [];
 

--- a/tests/diff/controller.test.ts
+++ b/tests/diff/controller.test.ts
@@ -253,3 +253,43 @@ describe("dispose", () => {
     expect(controller.isEqual).toBe(true);
   });
 });
+
+describe("Editor backspace in diff view", () => {
+  test("backspace at start of insert line merges with previous equal line", async () => {
+    // Scenario: old has "A\nC\n", new has "A\nB\nC\n" (B inserted between A and C)
+    const oldBuffer = createBuffer(createBufferId(), "A\nC\n");
+    const newBuffer = createBuffer(createBufferId(), "A\nB\nC\n");
+
+    // Use context=1 to include adjacent equal lines
+    const controller = createDiffController(oldBuffer, newBuffer, { context: 1 });
+    const mb = controller.multiBuffer;
+
+    // Diff result (with context=0):
+    // Row 0: equal "A" (new row 0)
+    // Row 1: insert "B" (new row 1)
+    // Row 2: equal "C" (new row 2)
+    expect(mb.lineCount).toBe(3);
+    expect(controller.isEqual).toBe(false);
+
+    // Verify the structure
+    const snap = mb.snapshot();
+    // biome-ignore lint/plugin/no-type-assertion: expect: branded type for test
+    const lines = snap.lines(0 as import("../../src/multibuffer/types.ts").MultiBufferRow, 3 as import("../../src/multibuffer/types.ts").MultiBufferRow);
+    expect(lines).toEqual(["A", "B", "C"]);
+
+    // Now simulate backspace at start of row 1 (the insert line "B")
+    // This should delete the newline at end of row 0, merging "A" and "B" into "AB"
+    const { Editor } = await import("../../src/editor/editor.ts");
+    const editor = new Editor(mb);
+
+    // Position cursor at start of row 1 (the insert line)
+    // biome-ignore lint/plugin/no-type-assertion: expect: branded type for test
+    editor.setCursor({ row: 1 as import("../../src/multibuffer/types.ts").MultiBufferRow, column: 0 });
+
+    // Dispatch backspace
+    editor.dispatch({ type: "deleteBackward", granularity: "character" });
+
+    // The edit should have been applied - newBuffer should now be "AB\nC\n"
+    expect(newBuffer.snapshot().text()).toBe("AB\nC\n");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes backspace at the start of an insert line not merging with the previous equal line in diff view.

**Root cause:** When an edit crosses excerpt boundaries (e.g., from an "equal" excerpt to an "insert" excerpt), the code was splitting the edit into per-excerpt sub-edits. This failed to delete the newline at the boundary because it's not part of either excerpt's content.

**Fix:** When all spanned excerpts are from the same buffer, call `multiBuffer.edit()` directly with the buffer coordinates instead of splitting by excerpt. This correctly handles boundary newlines.

## Test plan

- [x] Added test: backspace at start of insert line merges with previous equal line
- [x] All 821 tests pass
- [x] Typecheck clean
- [x] Lint clean