### PR TITLE
perf(highlighter): remove redundant token sort

### DIFF
--- a/src/renderer/highlighter.ts
+++ b/src/renderer/highlighter.ts
@@ -62,7 +62,7 @@ export class Highlighter implements SyntaxHighlighter {
 
   /**
    * Get syntax tokens for a specific line of a buffer.
-   * Returns tokens sorted by startColumn with pre-resolved colors.
+   * Returns tokens in startColumn order (guaranteed by depth-first tree traversal).
    */
   getLineTokens(bufferId: string, row: number): Token[] {
     const tree = this._trees.get(bufferId);
@@ -70,7 +70,6 @@ export class Highlighter implements SyntaxHighlighter {
 
     const tokens: Token[] = [];
     this._collectTokens(tree.rootNode, row, tokens, null);
-    tokens.sort((a, b) => a.startColumn - b.startColumn);
     return tokens;
   }
 


### PR DESCRIPTION
## Summary
- Remove unnecessary `tokens.sort()` call in `getLineTokens`
- `_collectTokens` does a depth-first traversal of the tree-sitter AST, which already visits children left-to-right, producing tokens in `startColumn` order
- Eliminates O(n log n) sort on every `getLineTokens` call

## Test plan
- [x] `bun run typecheck` — pass
- [x] `bun test` — 821 pass, 0 fail

Closes #178