### PR TITLE
perf: replace split('\n').length with buf.lineCount in demo

### DIFF
--- a/playground/demo.ts
+++ b/playground/demo.ts
@@ -64,7 +64,7 @@ async function main() {
     // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
     const buf = createBuffer(src.path as BufferId, src.content);
     bufferObjects.set(src.path, buf);
-    const lineCount = src.content.split("\n").length;
+    const lineCount = buf.snapshot().lineCount;
 
     if (src.path.includes("single-line")) {
       mb.addExcerpt(buf, range(0, lineCount), { hasTrailingNewline: true });
@@ -242,7 +242,7 @@ async function main() {
     for (const src of sources) {
       // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
       const buf = createBuffer(src.path as BufferId, src.content);
-      const lineCount = src.content.split("\n").length;
+      const lineCount = buf.snapshot().lineCount;
       if (src.path.includes("single-line")) {
         m.addExcerpt(buf, range(0, lineCount), { hasTrailingNewline: true });
       } else if (src.path.includes("large-file")) {
@@ -264,7 +264,7 @@ async function main() {
         if (!src) return;
         // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
         const buf = createBuffer(src.path as BufferId, src.content);
-        const lineCount = src.content.split("\n").length;
+        const lineCount = buf.snapshot().lineCount;
         m.addExcerpt(buf, range(0, lineCount), { hasTrailingNewline: true });
       },
     },
@@ -275,7 +275,7 @@ async function main() {
         for (const src of sources) {
           // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
           const buf = createBuffer(src.path as BufferId, src.content);
-          const lineCount = src.content.split("\n").length;
+          const lineCount = buf.snapshot().lineCount;
           for (let start = 0; start + 3 <= lineCount; start += 10) {
             m.addExcerpt(buf, range(start, Math.min(start + 3, lineCount)), {
               hasTrailingNewline: true,
@@ -292,7 +292,7 @@ async function main() {
         if (!src) return;
         // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
         const buf = createBuffer(src.path as BufferId, src.content);
-        m.addExcerpt(buf, range(0, src.content.split("\n").length), {
+        m.addExcerpt(buf, range(0, buf.snapshot().lineCount), {
           hasTrailingNewline: true,
         });
       },
@@ -305,7 +305,7 @@ async function main() {
         if (!src) return;
         // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
         const buf = createBuffer(src.path as BufferId, src.content);
-        m.addExcerpt(buf, range(0, src.content.split("\n").length), {
+        m.addExcerpt(buf, range(0, buf.snapshot().lineCount), {
           hasTrailingNewline: true,
         });
       },
@@ -320,7 +320,7 @@ async function main() {
         if (!src) return;
         // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
         const buf = createBuffer(src.path as BufferId, src.content);
-        m.addExcerpt(buf, range(0, src.content.split("\n").length), {
+        m.addExcerpt(buf, range(0, buf.snapshot().lineCount), {
           hasTrailingNewline: true,
         });
       },
@@ -333,7 +333,7 @@ async function main() {
         if (!src) return;
         // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction in demo
         const buf = createBuffer(src.path as BufferId, src.content);
-        m.addExcerpt(buf, range(0, src.content.split("\n").length), {
+        m.addExcerpt(buf, range(0, buf.snapshot().lineCount), {
           hasTrailingNewline: true,
         });
       },


### PR DESCRIPTION
## Summary
- Replaces 8 instances of `src.content.split("\n").length` with `buf.snapshot().lineCount` in `playground/demo.ts`
- Each `split()` call allocated a temporary 29K-element array just to get `.length` — Buffer already exposes O(1) `lineCount` via rope metadata

Part of #207.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — all tests pass