### PR TITLE
fix(ci): exclude .github/workflows/ from doc unbloat targets

### DIFF
--- a/.github/workflows/unbloat-docs.md
+++ b/.github/workflows/unbloat-docs.md
@@ -118,6 +118,7 @@ Scan the repository for markdown documentation files. Common locations include:
 - Changelog files
 - License files
 - Code of conduct files
+- **Workflow definition files in `.github/workflows/`** - These are workflow configs, not documentation
 - **Files with `disable-agentic-editing: true` in frontmatter** - These files are protected from automated editing
 
 Look for documentation files that were recently modified or are likely to benefit from cleanup.
@@ -134,6 +135,7 @@ Look for documentation files that were recently modified or are likely to benefi
 - Auto-generated documentation
 - Changelog or release notes
 - License or legal files
+- **Any file under `.github/workflows/`** - These are workflow definitions with protected paths
 - **Files with `disable-agentic-editing: true` in frontmatter** - These files are explicitly protected from automated editing
 
 Before selecting a file, check its frontmatter to ensure it doesn't have `disable-agentic-editing: true`:

--- a/tests/multibuffer/multibuffer.test.ts
+++ b/tests/multibuffer/multibuffer.test.ts
@@ -1216,7 +1216,9 @@ describe("MultiBuffer - Snapshot version", () => {
     mb.addExcerpt(buf, excerptRange(20, 30));
     versions.push(mb.snapshot().version);
     for (let i = 1; i < versions.length; i++) {
-      expect(versions[i]).toBeGreaterThan(versions[i - 1] as number);
+      const prev = versions[i - 1];
+      expect(prev).toBeDefined();
+      expect(versions[i]).toBeGreaterThan(prev ?? 0);
     }
   });
 });


### PR DESCRIPTION
## Summary
- The `Docs / Doc Unbloat` scheduled workflow was failing because it selected `.github/workflows/repo-assist.md` for cleanup, but `.github/` is a protected path prefix in safe-outputs config
- Added explicit exclusion rules in the unbloat-docs agent instructions so it never picks workflow definition files
- Fixed a pre-existing `as number` type assertion lint error in multibuffer tests that was blocking commits on main

## Test plan
- [x] `bun run lint` passes
- [x] `bun test tests/multibuffer/multibuffer.test.ts` — 91 pass, 0 fail