### PR TITLE
feat(react): add React integration bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,18 @@
     "./diff": {
       "import": "./src/diff/index.ts",
       "types": "./src/diff/index.ts"
+    },
+    "./react": {
+      "import": "./src/react/index.ts",
+      "types": "./src/react/index.ts"
+    }
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
     }
   },
   "type": "module",
@@ -46,7 +58,9 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
     "@types/bun": "latest",
+    "@types/react": "^18.2.0",
     "@vscode/tree-sitter-wasm": "^0.3.0",
+    "react": "^18.2.0",
     "tree-sitter-wasms": "^0.1.13",
     "typescript": "^5"
   },

--- a/src/react/diff-view.tsx
+++ b/src/react/diff-view.tsx
@@ -1,0 +1,138 @@
+/**
+ * DiffView - React component for displaying a diff between two text strings.
+ *
+ * Declarative wrapper around useDiffView for simple diff rendering.
+ *
+ * @example
+ * ```tsx
+ * <DiffView
+ *   oldText="hello\nworld"
+ *   newText="hello\nthere"
+ *   readOnly
+ *   style={{ height: 400 }}
+ * />
+ * ```
+ */
+
+import { type CSSProperties, forwardRef, type HTMLAttributes, useImperativeHandle } from "react";
+import type { DiffController, DiffControllerOptions } from "../diff/controller.ts";
+import type { Editor } from "../editor/editor.ts";
+import type { Theme } from "../editor/editor-view.ts";
+import type { Keymap } from "../editor/types.ts";
+import type { Decoration, Measurements } from "../renderer/types.ts";
+import { useDiffView } from "./use-diff-view.ts";
+
+export interface DiffViewProps extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  /** The "old" or "before" text content. */
+  oldText: string;
+  /** The "new" or "after" text content. */
+  newText: string;
+  /** Read-only mode. Default: true. */
+  readOnly?: boolean;
+  /** Custom measurements (lineHeight, gutterWidth, charWidth, wrapWidth). */
+  measurements?: Partial<Omit<Measurements, "gutterMode">>;
+  /** Custom keymap merged on top of defaults. */
+  keymap?: Keymap;
+  /** Callback for custom commands from keymap. */
+  onCustomCommand?: (action: string) => void;
+  /** Theme CSS variables to apply. */
+  theme?: Theme;
+  /** Additional decorations to merge with diff decorations. */
+  decorations?: Decoration[];
+  /** Diff controller options (context lines, debounce, etc.). */
+  diffOptions?: DiffControllerOptions;
+  /** Callback when diff state changes. */
+  onDiffChange?: (isEqual: boolean, decorations: readonly Decoration[]) => void;
+}
+
+export interface DiffViewHandle {
+  /** The DiffController instance. */
+  controller: DiffController | null;
+  /** The underlying Editor instance. */
+  editor: Editor | null;
+  /** Whether the old and new text are equal. */
+  isEqual: boolean;
+  /** Current diff decorations. */
+  decorations: readonly Decoration[];
+  /** Update decorations imperatively. */
+  setDecorations: (key: string, decorations: Decoration[]) => void;
+  /** Update theme imperatively. */
+  setTheme: (theme: Theme) => void;
+  /** Force re-diff. */
+  reDiff: () => void;
+}
+
+/**
+ * DiffView component - renders a diff between two text strings.
+ *
+ * For more control, use the useDiffView hook directly.
+ */
+export const DiffView = forwardRef<DiffViewHandle, DiffViewProps>(function DiffView(
+  {
+    oldText,
+    newText,
+    readOnly = true,
+    measurements,
+    keymap,
+    onCustomCommand,
+    theme,
+    decorations,
+    diffOptions,
+    onDiffChange,
+    style,
+    className,
+    ...divProps
+  },
+  ref,
+) {
+  const {
+    containerRef,
+    controller,
+    isEqual,
+    decorations: diffDecorations,
+    editor,
+    setDecorations,
+    setTheme,
+    reDiff,
+  } = useDiffView({
+    oldText,
+    newText,
+    readOnly,
+    measurements,
+    keymap,
+    onCustomCommand,
+    theme,
+    decorations,
+    diffOptions,
+    onDiffChange,
+  });
+
+  // Expose imperative handle
+  useImperativeHandle(ref, () => ({
+    controller,
+    editor,
+    isEqual,
+    decorations: diffDecorations,
+    setDecorations,
+    setTheme,
+    reDiff,
+  }), [controller, editor, isEqual, diffDecorations, setDecorations, setTheme, reDiff]);
+
+  // Default styles for the container
+  const containerStyle: CSSProperties = {
+    position: "relative",
+    overflow: "hidden",
+    fontFamily: "monospace",
+    fontSize: 14,
+    ...style,
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      style={containerStyle}
+      {...divProps}
+    />
+  );
+});

--- a/src/react/editor-view.tsx
+++ b/src/react/editor-view.tsx
@@ -1,0 +1,114 @@
+/**
+ * EditorViewComponent - React component for rendering an editor.
+ *
+ * Declarative wrapper around useEditorView for simple editor rendering.
+ * Named EditorViewComponent to avoid collision with the core EditorView type.
+ *
+ * @example
+ * ```tsx
+ * <EditorViewComponent
+ *   text="hello\nworld"
+ *   readOnly={false}
+ *   style={{ height: 400 }}
+ * />
+ * ```
+ */
+
+import { type CSSProperties, forwardRef, type HTMLAttributes, useImperativeHandle } from "react";
+import type { EditorView, Theme } from "../editor/editor-view.ts";
+import type { Keymap } from "../editor/types.ts";
+import type { Decoration, Measurements } from "../renderer/types.ts";
+import { useEditorView } from "./use-editor-view.ts";
+
+export interface EditorViewComponentProps extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  /** Initial text content. Changes after mount are ignored (uncontrolled). */
+  text: string;
+  /** Read-only mode. Can be updated after mount. */
+  readOnly?: boolean;
+  /** Enable bracket matching. */
+  bracketMatching?: boolean;
+  /** Custom measurements (lineHeight, gutterWidth, charWidth, wrapWidth, gutterMode). */
+  measurements?: Partial<Measurements>;
+  /** Custom keymap merged on top of defaults. */
+  keymap?: Keymap;
+  /** Callback for custom commands from keymap. */
+  onCustomCommand?: (action: string) => void;
+  /** Theme CSS variables to apply. */
+  theme?: Theme;
+  /** Decorations to render. Can be updated after mount. */
+  decorations?: Decoration[];
+}
+
+export interface EditorViewComponentHandle {
+  /** The EditorView instance. */
+  view: EditorView | null;
+  /** Update decorations imperatively. */
+  setDecorations: (key: string, decorations: Decoration[]) => void;
+  /** Update theme imperatively. */
+  setTheme: (theme: Theme) => void;
+}
+
+/**
+ * EditorViewComponent - renders a text editor.
+ *
+ * For more control, use the useEditorView hook directly.
+ */
+export const EditorViewComponent = forwardRef<EditorViewComponentHandle, EditorViewComponentProps>(
+  function EditorViewComponent(
+    {
+      text,
+      readOnly,
+      bracketMatching,
+      measurements,
+      keymap,
+      onCustomCommand,
+      theme,
+      decorations,
+      style,
+      className,
+      ...divProps
+    },
+    ref,
+  ) {
+    const {
+      containerRef,
+      view,
+      setDecorations,
+      setTheme,
+    } = useEditorView({
+      text,
+      readOnly,
+      bracketMatching,
+      measurements,
+      keymap,
+      onCustomCommand,
+      theme,
+      decorations,
+    });
+
+    // Expose imperative handle
+    useImperativeHandle(ref, () => ({
+      view,
+      setDecorations,
+      setTheme,
+    }), [view, setDecorations, setTheme]);
+
+    // Default styles for the container
+    const containerStyle: CSSProperties = {
+      position: "relative",
+      overflow: "hidden",
+      fontFamily: "monospace",
+      fontSize: 14,
+      ...style,
+    };
+
+    return (
+      <div
+        ref={containerRef}
+        className={className}
+        style={containerStyle}
+        {...divProps}
+      />
+    );
+  },
+);

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,0 +1,40 @@
+/**
+ * React bindings for multibuffer.
+ *
+ * Provides hooks and components for integrating multibuffer's editor
+ * and diff views into React applications.
+ *
+ * @example
+ * ```tsx
+ * import { DiffView, useDiffView, useEditorView, EditorViewComponent } from "multibuffer/react";
+ *
+ * // Simple diff view component
+ * <DiffView oldText={old} newText={new} />
+ *
+ * // Diff view with hook for more control
+ * const { containerRef, isEqual } = useDiffView({ oldText, newText });
+ *
+ * // Simple editor component
+ * <EditorViewComponent text={content} />
+ *
+ * // Editor with hook for more control
+ * const { containerRef, view } = useEditorView({ text: initialText });
+ * ```
+ */
+
+export type { DiffController, DiffControllerOptions } from "../diff/controller.ts";
+export type { Editor } from "../editor/editor.ts";
+export type { EditorView, Theme } from "../editor/editor-view.ts";
+export type { EditorCommand, KeyBinding, Keymap } from "../editor/types.ts";
+// Re-export commonly needed types from core
+export type { Decoration, Measurements, Viewport } from "../renderer/types.ts";
+export type { DiffViewHandle, DiffViewProps } from "./diff-view.tsx";
+export { DiffView } from "./diff-view.tsx";
+// Components
+export type { EditorViewComponentHandle, EditorViewComponentProps } from "./editor-view.tsx";
+export { EditorViewComponent } from "./editor-view.tsx";
+export type { UseDiffViewOptions, UseDiffViewResult } from "./use-diff-view.ts";
+export { useDiffView } from "./use-diff-view.ts";
+// Hooks
+export type { UseEditorViewOptions, UseEditorViewResult } from "./use-editor-view.ts";
+export { useEditorView } from "./use-editor-view.ts";

--- a/src/react/use-diff-view.ts
+++ b/src/react/use-diff-view.ts
@@ -1,0 +1,406 @@
+/**
+ * useDiffView - React hook for rendering a diff between two text strings.
+ *
+ * Creates and manages a DiffController, EditorView, and handles automatic
+ * re-diffing when oldText or newText props change.
+ *
+ * @example
+ * ```tsx
+ * function MyDiffViewer({ oldText, newText }: Props) {
+ *   const { containerRef, isEqual } = useDiffView({ oldText, newText, readOnly: true });
+ *   return (
+ *     <div>
+ *       {isEqual && <span>Files are identical</span>}
+ *       <div ref={containerRef} style={{ height: 400 }} />
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createBuffer } from "../buffer/buffer.ts";
+import type { Buffer, BufferId } from "../buffer/types.ts";
+import type { DiffController, DiffControllerOptions } from "../diff/controller.ts";
+import { createDiffController } from "../diff/controller.ts";
+import type { Editor } from "../editor/editor.ts";
+import type { Theme } from "../editor/editor-view.ts";
+import { mergeDecorations } from "../editor/editor-view.ts";
+import { createMultiBufferEditor } from "../editor/factories.ts";
+import { InputHandler } from "../editor/input-handler.ts";
+import type { Keymap } from "../editor/types.ts";
+import { resolveAnchorRange } from "../multibuffer/anchor.ts";
+import type { MultiBufferRow } from "../multibuffer/types.ts";
+import { createDomRenderer } from "../renderer/dom.ts";
+import type { Decoration, Measurements } from "../renderer/types.ts";
+
+let _diffBufferIdCounter = 0;
+
+function nextDiffBufferId(prefix: string): BufferId {
+  // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction for internal buffer ID
+  return `diff-${prefix}-${_diffBufferIdCounter++}` as BufferId;
+}
+
+export interface UseDiffViewOptions {
+  /** The "old" or "before" text content. */
+  oldText: string;
+  /** The "new" or "after" text content. */
+  newText: string;
+  /** Read-only mode. Default: true for diff views. */
+  readOnly?: boolean;
+  /** Custom measurements (lineHeight, gutterWidth, charWidth, wrapWidth). gutterMode is forced to "diff". */
+  measurements?: Partial<Omit<Measurements, "gutterMode">>;
+  /** Custom keymap merged on top of defaults. */
+  keymap?: Keymap;
+  /** Callback for custom commands from keymap. */
+  onCustomCommand?: (action: string) => void;
+  /** Theme CSS variables to apply. */
+  theme?: Theme;
+  /** Additional decorations to merge with diff decorations. */
+  decorations?: Decoration[];
+  /** Diff controller options (context lines, debounce, etc.). */
+  diffOptions?: DiffControllerOptions;
+  /** Callback when diff state changes. */
+  onDiffChange?: (isEqual: boolean, decorations: readonly Decoration[]) => void;
+}
+
+export interface UseDiffViewResult {
+  /** Ref to attach to the container element. */
+  containerRef: React.RefObject<HTMLDivElement>;
+  /** The DiffController instance (null during SSR or before mount). */
+  controller: DiffController | null;
+  /** Whether the old and new text are equal. */
+  isEqual: boolean;
+  /** Current diff decorations. */
+  decorations: readonly Decoration[];
+  /** The underlying Editor instance (null during SSR or before mount). */
+  editor: Editor | null;
+  /** Update additional decorations imperatively. */
+  setDecorations: (key: string, decorations: Decoration[]) => void;
+  /** Update theme imperatively. */
+  setTheme: (theme: Theme) => void;
+  /** Force re-diff (normally automatic on prop changes). */
+  reDiff: () => void;
+}
+
+/**
+ * React hook for creating and managing a diff view.
+ *
+ * Automatically re-diffs when oldText or newText props change.
+ */
+export function useDiffView(options: UseDiffViewOptions): UseDiffViewResult {
+  // biome-ignore lint/style/noNonNullAssertion: expect: ref will be assigned by React before first effect runs
+  const containerRef = useRef<HTMLDivElement>(null!);
+
+  // Core instances
+  const controllerRef = useRef<DiffController | null>(null);
+  const editorRef = useRef<Editor | null>(null);
+  const rendererRef = useRef<ReturnType<typeof createDomRenderer> | null>(null);
+  const inputHandlerRef = useRef<InputHandler | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+  const decorationsMapRef = useRef(new Map<string, Decoration[]>());
+
+  // React state for re-renders
+  const [controller, setController] = useState<DiffController | null>(null);
+  const [isEqual, setIsEqual] = useState(false);
+  const [decorations, setDecorations] = useState<readonly Decoration[]>([]);
+  const [editor, setEditor] = useState<Editor | null>(null);
+
+  // Store latest options in refs
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  // Buffer refs (mutable to allow text replacement)
+  const oldBufferRef = useRef<Buffer | null>(null);
+  const newBufferRef = useRef<Buffer | null>(null);
+
+  // Track text for change detection
+  const prevOldTextRef = useRef<string | null>(null);
+  const prevNewTextRef = useRef<string | null>(null);
+
+  // Schedule render using RAF
+  // biome-ignore lint/correctness/useExhaustiveDependencies: render is stable (uses only refs)
+  const scheduleRender = useCallback(() => {
+    if (rafIdRef.current !== null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      render();
+    });
+  }, []);
+
+  // Render function
+  const render = useCallback(() => {
+    const ed = editorRef.current;
+    const renderer = rendererRef.current;
+    const ctrl = controllerRef.current;
+    const inputHandler = inputHandlerRef.current;
+    if (!ed || !renderer || !ctrl) return;
+
+    const snap = ed.multiBuffer.snapshot();
+    renderer.setSnapshot(snap);
+
+    const viewport = renderer.getViewport();
+    const { startRow, endRow } = viewport;
+    const lines = snap.lines(startRow, endRow);
+    const boundaries = snap.excerptBoundaries(startRow, endRow);
+
+    // Build excerpt headers
+    const excerptHeaders = boundaries
+      .filter((b) => b.prev !== undefined)
+      .map((b) => ({
+        // biome-ignore lint/plugin/no-type-assertion: expect: branded arithmetic for header row offset
+        row: (b.row - 1) as MultiBufferRow,
+        path: b.next.bufferId,
+        label: `L${b.next.range.context.start.row + 1}\u2013${b.next.range.context.end.row}`,
+      }));
+
+    // Merge decorations: diff decorations + user decorations
+    decorationsMapRef.current.set("diff", [...ctrl.decorations]);
+    const allDecorations = mergeDecorations(decorationsMapRef.current);
+
+    renderer.render(
+      {
+        viewport,
+        selections: ed.selection ? [ed.selection] : [],
+        decorations: allDecorations,
+        excerptHeaders,
+        focused: inputHandler?.hasFocus ?? false,
+      },
+      lines,
+    );
+
+    // Render cursor and selection
+    renderer.renderCursor(ed.cursor);
+    if (ed.selection) {
+      const resolved = resolveAnchorRange(snap, ed.selection.range);
+      renderer.renderSelection(resolved?.start, resolved?.end);
+    } else {
+      renderer.renderSelection(undefined, undefined);
+    }
+  }, []);
+
+  // Initialize on mount
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only effect; render/scheduleRender are stable (use only refs)
+  useEffect(() => {
+    // SSR safety
+    if (typeof document === "undefined") return;
+    if (!containerRef.current) return;
+
+    const opts = optionsRef.current;
+    const container = containerRef.current;
+
+    // Create buffers
+    const oldBuffer = createBuffer(nextDiffBufferId("old"), opts.oldText);
+    const newBuffer = createBuffer(nextDiffBufferId("new"), opts.newText);
+    oldBufferRef.current = oldBuffer;
+    newBufferRef.current = newBuffer;
+    prevOldTextRef.current = opts.oldText;
+    prevNewTextRef.current = opts.newText;
+
+    // Create diff controller
+    const ctrl = createDiffController(oldBuffer, newBuffer, opts.diffOptions);
+    controllerRef.current = ctrl;
+    setController(ctrl);
+    setIsEqual(ctrl.isEqual);
+    setDecorations(ctrl.decorations);
+
+    // Create editor from diff's multiBuffer
+    const ed = createMultiBufferEditor(ctrl.multiBuffer, {
+      readOnly: opts.readOnly ?? true,
+    });
+    editorRef.current = ed;
+    setEditor(ed);
+
+    // Create renderer with diff gutter mode
+    const measurements: Measurements = {
+      lineHeight: opts.measurements?.lineHeight ?? 20,
+      gutterWidth: opts.measurements?.gutterWidth ?? 96, // Wider for diff gutters
+      charWidth: opts.measurements?.charWidth,
+      wrapWidth: opts.measurements?.wrapWidth,
+      gutterMode: "diff",
+    };
+    const renderer = createDomRenderer(measurements);
+    rendererRef.current = renderer;
+
+    // Create input handler
+    const inputHandler = new InputHandler(
+      (cmd) => {
+        if (cmd.type === "copy" || cmd.type === "cut") {
+          const selected = ed.getSelectedText();
+          if (selected && typeof navigator !== "undefined") {
+            navigator.clipboard?.writeText(selected);
+          }
+        }
+        ed.dispatch(cmd);
+      },
+      { keymap: opts.keymap },
+    );
+    inputHandlerRef.current = inputHandler;
+
+    if (opts.onCustomCommand) {
+      ed.onCustomCommand(opts.onCustomCommand);
+    }
+
+    // Mount
+    renderer.mount(container);
+    inputHandler.mount(container);
+
+    // Wire click/drag callbacks
+    renderer.onClickPosition((point) => {
+      ed.setCursor(point);
+      inputHandler.focus();
+    });
+    renderer.onDrag((point) => {
+      ed.extendSelectionTo(point);
+    });
+    renderer.onDoubleClick((point) => {
+      ed.selectWordAt(point);
+    });
+    renderer.onTripleClick((point) => {
+      ed.selectLineAt(point);
+    });
+
+    // Subscribe to editor changes
+    const onEditorChange = () => scheduleRender();
+    ed.on("change", onEditorChange);
+
+    // Subscribe to diff updates
+    const unsubscribeDiff = ctrl.onUpdate((newDecorations) => {
+      setDecorations(newDecorations);
+      setIsEqual(ctrl.isEqual);
+      scheduleRender();
+      opts.onDiffChange?.(ctrl.isEqual, newDecorations);
+    });
+
+    // Apply initial theme
+    if (opts.theme) {
+      for (const [key, value] of Object.entries(opts.theme)) {
+        container.style.setProperty(key, value);
+      }
+    }
+
+    // Apply initial user decorations
+    if (opts.decorations) {
+      decorationsMapRef.current.set("user", opts.decorations);
+    }
+
+    // Set initial snapshot and render
+    const initialSnap = ctrl.multiBuffer.snapshot();
+    renderer.setSnapshot(initialSnap);
+    render();
+
+    // Cleanup
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      ed.off("change", onEditorChange);
+      unsubscribeDiff();
+      ctrl.dispose();
+      inputHandler.unmount();
+      renderer.unmount();
+
+      controllerRef.current = null;
+      editorRef.current = null;
+      rendererRef.current = null;
+      inputHandlerRef.current = null;
+      oldBufferRef.current = null;
+      newBufferRef.current = null;
+
+      setController(null);
+      setEditor(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Handle text changes - recreate buffers and re-diff
+  useEffect(() => {
+    const ctrl = controllerRef.current;
+    const oldBuffer = oldBufferRef.current;
+    const newBuffer = newBufferRef.current;
+    if (!ctrl || !oldBuffer || !newBuffer) return;
+
+    const oldChanged = options.oldText !== prevOldTextRef.current;
+    const newChanged = options.newText !== prevNewTextRef.current;
+
+    if (!oldChanged && !newChanged) return;
+
+    // Replace buffer contents and re-diff
+    if (oldChanged) {
+      const snap = oldBuffer.snapshot();
+      const len = snap.textSummary.chars;
+      // biome-ignore lint/plugin/no-type-assertion: expect: branded type for buffer offset
+      oldBuffer.replace(0 as import("../buffer/types.ts").BufferOffset, len as import("../buffer/types.ts").BufferOffset, options.oldText);
+      prevOldTextRef.current = options.oldText;
+    }
+
+    if (newChanged) {
+      const snap = newBuffer.snapshot();
+      const len = snap.textSummary.chars;
+      // biome-ignore lint/plugin/no-type-assertion: expect: branded type for buffer offset
+      newBuffer.replace(0 as import("../buffer/types.ts").BufferOffset, len as import("../buffer/types.ts").BufferOffset, options.newText);
+      prevNewTextRef.current = options.newText;
+    }
+
+    // Trigger re-diff
+    ctrl.reDiff();
+  }, [options.oldText, options.newText]);
+
+  // Sync readOnly changes
+  useEffect(() => {
+    if (editorRef.current && options.readOnly !== undefined) {
+      editorRef.current.setReadOnly(options.readOnly);
+    }
+  }, [options.readOnly]);
+
+  // Sync theme changes
+  useEffect(() => {
+    if (containerRef.current && options.theme) {
+      for (const [key, value] of Object.entries(options.theme)) {
+        containerRef.current.style.setProperty(key, value);
+      }
+    }
+  }, [options.theme]);
+
+  // Sync user decorations
+  useEffect(() => {
+    if (options.decorations) {
+      decorationsMapRef.current.set("user", options.decorations);
+      scheduleRender();
+    }
+  }, [options.decorations, scheduleRender]);
+
+  // Imperative APIs
+  const setDecorationsImperative = useCallback((key: string, decs: Decoration[]) => {
+    if (decs.length === 0) {
+      decorationsMapRef.current.delete(key);
+    } else {
+      decorationsMapRef.current.set(key, decs);
+    }
+    scheduleRender();
+  }, [scheduleRender]);
+
+  const setThemeImperative = useCallback((theme: Theme) => {
+    if (containerRef.current) {
+      for (const [key, value] of Object.entries(theme)) {
+        containerRef.current.style.setProperty(key, value);
+      }
+    }
+  }, []);
+
+  const reDiffImperative = useCallback(() => {
+    controllerRef.current?.reDiff();
+  }, []);
+
+  return {
+    containerRef,
+    controller,
+    isEqual,
+    decorations,
+    editor,
+    setDecorations: setDecorationsImperative,
+    setTheme: setThemeImperative,
+    reDiff: reDiffImperative,
+  };
+}

--- a/src/react/use-editor-view.ts
+++ b/src/react/use-editor-view.ts
@@ -1,0 +1,147 @@
+/**
+ * useEditorView - React hook for mounting an EditorView into a container.
+ *
+ * Handles lifecycle (create on mount, destroy on unmount), SSR safety,
+ * and prop synchronization without full teardown on every render.
+ *
+ * @example
+ * ```tsx
+ * function MyEditor({ initialText }: Props) {
+ *   const { containerRef, view } = useEditorView({ text: initialText });
+ *   return <div ref={containerRef} style={{ height: 400 }} />;
+ * }
+ * ```
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { EditorView, EditorViewOptions, Theme } from "../editor/editor-view.ts";
+import { createEditorView } from "../editor/editor-view.ts";
+import type { Keymap } from "../editor/types.ts";
+import type { Decoration, Measurements } from "../renderer/types.ts";
+
+export interface UseEditorViewOptions {
+  /** Initial text content. Changes after mount are ignored (uncontrolled). */
+  text: string;
+  /** Read-only mode. Can be updated after mount. */
+  readOnly?: boolean;
+  /** Enable bracket matching. */
+  bracketMatching?: boolean;
+  /** Custom measurements (lineHeight, gutterWidth, charWidth, wrapWidth, gutterMode). */
+  measurements?: Partial<Measurements>;
+  /** Custom keymap merged on top of defaults. */
+  keymap?: Keymap;
+  /** Callback for custom commands from keymap. */
+  onCustomCommand?: (action: string) => void;
+  /** Theme CSS variables to apply. Can be updated after mount. */
+  theme?: Theme;
+  /** Decorations to render. Can be updated after mount. */
+  decorations?: Decoration[];
+}
+
+export interface UseEditorViewResult {
+  /** Ref to attach to the container element. */
+  containerRef: React.RefObject<HTMLDivElement>;
+  /** The EditorView instance (null during SSR or before mount). */
+  view: EditorView | null;
+  /** Update decorations imperatively (alternative to props). */
+  setDecorations: (key: string, decorations: Decoration[]) => void;
+  /** Update theme imperatively (alternative to props). */
+  setTheme: (theme: Theme) => void;
+}
+
+/**
+ * React hook for creating and managing an EditorView.
+ *
+ * The `text` prop is used only on initial mount (uncontrolled pattern).
+ * For controlled content, use the view.editor API directly.
+ */
+export function useEditorView(options: UseEditorViewOptions): UseEditorViewResult {
+  // biome-ignore lint/style/noNonNullAssertion: expect: ref will be assigned by React before first effect runs
+  const containerRef = useRef<HTMLDivElement>(null!);
+  const viewRef = useRef<EditorView | null>(null);
+  const [view, setView] = useState<EditorView | null>(null);
+
+  // Store latest options in refs to avoid re-creating view on every render
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  // Create view on mount, destroy on unmount
+  useEffect(() => {
+    // SSR safety: skip if no document
+    if (typeof document === "undefined") return;
+    if (!containerRef.current) return;
+
+    const opts = optionsRef.current;
+    const editorViewOptions: EditorViewOptions = {
+      readOnly: opts.readOnly,
+      bracketMatching: opts.bracketMatching,
+      measurements: opts.measurements,
+      keymap: opts.keymap,
+      onCustomCommand: opts.onCustomCommand,
+    };
+
+    const editorView = createEditorView(
+      containerRef.current,
+      opts.text,
+      editorViewOptions,
+    );
+
+    // Apply initial theme if provided
+    if (opts.theme) {
+      editorView.setTheme(opts.theme);
+    }
+
+    // Apply initial decorations if provided
+    if (opts.decorations) {
+      editorView.setDecorations("props", opts.decorations);
+    }
+
+    viewRef.current = editorView;
+    setView(editorView);
+
+    return () => {
+      editorView.destroy();
+      viewRef.current = null;
+      setView(null);
+    };
+    // Only run on mount/unmount - text is initial value only
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync readOnly changes
+  useEffect(() => {
+    if (viewRef.current && options.readOnly !== undefined) {
+      viewRef.current.editor.setReadOnly(options.readOnly);
+    }
+  }, [options.readOnly]);
+
+  // Sync theme changes
+  useEffect(() => {
+    if (viewRef.current && options.theme) {
+      viewRef.current.setTheme(options.theme);
+    }
+  }, [options.theme]);
+
+  // Sync decoration changes
+  useEffect(() => {
+    if (viewRef.current && options.decorations) {
+      viewRef.current.setDecorations("props", options.decorations);
+    }
+  }, [options.decorations]);
+
+  // Imperative API
+  const setDecorations = useCallback((key: string, decorations: Decoration[]) => {
+    viewRef.current?.setDecorations(key, decorations);
+  }, []);
+
+  const setTheme = useCallback((theme: Theme) => {
+    viewRef.current?.setTheme(theme);
+  }, []);
+
+  return {
+    containerRef,
+    view,
+    setDecorations,
+    setTheme,
+  };
+}

--- a/tests/react/react.test.ts
+++ b/tests/react/react.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for React bindings (issue #264).
+ *
+ * React hooks require a DOM environment and React testing utilities.
+ * These tests cover compile-time type checks and verifying exports
+ * are accessible. Full integration tests would require happy-dom/jsdom
+ * and @testing-library/react.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+// ── Type export smoke tests ─────────────────────────────────────────────────
+
+// These imports verify that the exports compile correctly.
+import type {
+  UseEditorViewOptions,
+  UseEditorViewResult,
+  UseDiffViewOptions,
+  UseDiffViewResult,
+  DiffViewProps,
+  DiffViewHandle,
+  EditorViewComponentProps,
+  EditorViewComponentHandle,
+  Decoration,
+  Measurements,
+  Viewport,
+  Theme,
+  EditorView,
+  Editor,
+  DiffController,
+  DiffControllerOptions,
+  Keymap,
+  KeyBinding,
+  EditorCommand,
+} from "../../src/react/index.ts";
+
+// Verify hooks and components are exported
+import {
+  useEditorView,
+  useDiffView,
+  DiffView,
+  EditorViewComponent,
+} from "../../src/react/index.ts";
+
+describe("React bindings exports", () => {
+  test("useEditorView is exported as a function", () => {
+    expect(typeof useEditorView).toBe("function");
+  });
+
+  test("useDiffView is exported as a function", () => {
+    expect(typeof useDiffView).toBe("function");
+  });
+
+  test("DiffView is exported", () => {
+    expect(DiffView).toBeDefined();
+  });
+
+  test("EditorViewComponent is exported", () => {
+    expect(EditorViewComponent).toBeDefined();
+  });
+});
+
+// ── UseEditorViewOptions type check ─────────────────────────────────────────
+
+describe("UseEditorViewOptions", () => {
+  test("accepts all expected fields without TypeScript error", () => {
+    const opts: UseEditorViewOptions = {
+      text: "hello world",
+      readOnly: true,
+      bracketMatching: true,
+      measurements: {
+        lineHeight: 20,
+        gutterWidth: 48,
+        charWidth: 8,
+        wrapWidth: 80,
+      },
+      theme: {
+        "--editor-cursor": "#ffffff",
+      },
+      decorations: [],
+    };
+    expect(opts.text).toBe("hello world");
+    expect(opts.readOnly).toBe(true);
+  });
+
+  test("only text is required", () => {
+    const opts: UseEditorViewOptions = { text: "" };
+    expect(opts).toBeDefined();
+  });
+});
+
+// ── UseDiffViewOptions type check ───────────────────────────────────────────
+
+describe("UseDiffViewOptions", () => {
+  test("accepts all expected fields without TypeScript error", () => {
+    const opts: UseDiffViewOptions = {
+      oldText: "hello",
+      newText: "world",
+      readOnly: true,
+      measurements: {
+        lineHeight: 20,
+        gutterWidth: 96,
+      },
+      theme: {
+        "--editor-cursor": "#ffffff",
+      },
+      decorations: [],
+      diffOptions: {
+        context: 3,
+        debounceMs: 150,
+      },
+    };
+    expect(opts.oldText).toBe("hello");
+    expect(opts.newText).toBe("world");
+    expect(opts.readOnly).toBe(true);
+  });
+
+  test("only oldText and newText are required", () => {
+    const opts: UseDiffViewOptions = { oldText: "", newText: "" };
+    expect(opts).toBeDefined();
+  });
+});
+
+// ── DiffViewProps type check ────────────────────────────────────────────────
+
+describe("DiffViewProps", () => {
+  test("accepts all expected fields without TypeScript error", () => {
+    const props: DiffViewProps = {
+      oldText: "hello",
+      newText: "world",
+      readOnly: true,
+      style: { height: 400 },
+      className: "my-diff-view",
+    };
+    expect(props.oldText).toBe("hello");
+    expect(props.newText).toBe("world");
+  });
+
+  test("only oldText and newText are required", () => {
+    const props: DiffViewProps = { oldText: "", newText: "" };
+    expect(props).toBeDefined();
+  });
+});
+
+// ── EditorViewComponentProps type check ─────────────────────────────────────
+
+describe("EditorViewComponentProps", () => {
+  test("accepts all expected fields without TypeScript error", () => {
+    const props: EditorViewComponentProps = {
+      text: "hello world",
+      readOnly: true,
+      style: { height: 400 },
+      className: "my-editor",
+    };
+    expect(props.text).toBe("hello world");
+  });
+
+  test("only text is required", () => {
+    const props: EditorViewComponentProps = { text: "" };
+    expect(props).toBeDefined();
+  });
+});
+
+// ── Re-exported types type check ────────────────────────────────────────────
+
+describe("Re-exported types", () => {
+  test("Decoration type is accessible", () => {
+    const dec: Decoration = {
+      range: {
+        // biome-ignore lint/plugin/no-type-assertion: expect: branded type in test
+        start: { row: 0 as import("../../src/multibuffer/types.ts").MultiBufferRow, column: 0 },
+        // biome-ignore lint/plugin/no-type-assertion: expect: branded type in test
+        end: { row: 1 as import("../../src/multibuffer/types.ts").MultiBufferRow, column: 0 },
+      },
+      className: "test",
+    };
+    expect(dec.className).toBe("test");
+  });
+
+  test("Measurements type is accessible", () => {
+    const m: Measurements = {
+      lineHeight: 20,
+      gutterWidth: 48,
+    };
+    expect(m.lineHeight).toBe(20);
+  });
+
+  test("Theme type is accessible", () => {
+    const t: Theme = {
+      "--editor-bg": "#1d2021",
+    };
+    expect(t["--editor-bg"]).toBe("#1d2021");
+  });
+
+  test("Keymap type is accessible", () => {
+    const k: Keymap = {
+      "ctrl+s": { type: "custom", action: "save" },
+    };
+    expect(k["ctrl+s"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

First-class React bindings for multibuffer's DOM renderer. Closes #264.

- **`useEditorView`** hook: general-purpose hook for editor integration
- **`useDiffView`** hook: diff-specific hook with automatic re-diffing on prop changes
- **`<DiffView />`** component: declarative wrapper around useDiffView
- **`<EditorViewComponent />`**: declarative wrapper around useEditorView

### Features

- **SSR-safe**: renders nothing on server, hydrates on client
- **Concurrent mode safe**: uses effects for side effects only
- **Proper cleanup**: destroys renderer and disposes controller on unmount
- **Re-render efficient**: only updates what changed (readOnly, theme, decorations) without full teardown
- **Ref forwarding**: imperative handle exposes controller, editor, and methods

### Usage

```tsx
import { DiffView, useDiffView } from "multibuffer/react";

// Simple declarative API
function MyDiffViewer({ oldText, newText, filename }: Props) {
  return (
    <DiffView
      oldText={oldText}
      newText={newText}
      readOnly
      style={{ height: 400 }}
    />
  );
}

// Hook for more control
function CustomDiffViewer({ oldText, newText }: Props) {
  const { containerRef, controller, isEqual } = useDiffView({
    oldText,
    newText,
    readOnly: true,
  });

  return (
    <div>
      <div>Equal: {isEqual ? "yes" : "no"}</div>
      <div ref={containerRef} style={{ height: 400 }} />
    </div>
  );
}
```

### Package Changes

- New `multibuffer/react` subpath export
- React 18+ added as optional peer dependency

## Test plan

- [x] TypeScript compiles without errors (`bun run typecheck`)
- [x] Linter passes (`bun run lint`)
- [x] All 1156 tests pass (`bun test`)
- [x] Type export tests verify all exports are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)