### PR TITLE
feat(highlighter): add multi-language syntax highlighting support

### DIFF
--- a/src/renderer/highlighter.ts
+++ b/src/renderer/highlighter.ts
@@ -1,6 +1,60 @@
 /**
  * Tree-sitter based syntax highlighter.
  * Parses buffers once, then extracts tokens for visible lines on demand.
+ *
+ * ## Single-language usage (Highlighter)
+ *
+ * For simple use cases where all buffers use the same language:
+ *
+ * ```ts
+ * const highlighter = new Highlighter();
+ * await highlighter.init(treeSitterWasmUrl, typescriptWasmUrl);
+ * highlighter.parseBuffer("file.ts", sourceCode);
+ * const tokens = highlighter.getLineTokens("file.ts", 0);
+ * ```
+ *
+ * ## Multi-language usage (MultiLanguageHighlighter)
+ *
+ * For diff viewers and multi-file editors that need multiple languages:
+ *
+ * ```ts
+ * const highlighter = new MultiLanguageHighlighter();
+ * await highlighter.init(treeSitterWasmUrl, {
+ *   typescript: "/grammars/tree-sitter-typescript.wasm",
+ *   rust: "/grammars/tree-sitter-rust.wasm",
+ *   python: "/grammars/tree-sitter-python.wasm",
+ * });
+ *
+ * // Parse with explicit language
+ * highlighter.parseBuffer("main.rs", rustCode, undefined, "rust");
+ *
+ * // Or auto-detect from filename
+ * highlighter.parseBufferWithPath("src/main.rs", rustCode);
+ * ```
+ *
+ * ## Custom highlighter implementations
+ *
+ * Consumers can implement the {@link SyntaxHighlighter} interface to bring
+ * their own highlighting engine (e.g., Shiki, Prism, or TextMate grammars):
+ *
+ * ```ts
+ * class ShikiHighlighter implements SyntaxHighlighter {
+ *   ready = false;
+ *
+ *   async init(theme: string) {
+ *     // Load Shiki...
+ *     this.ready = true;
+ *   }
+ *
+ *   parseBuffer(bufferId: string, text: string) {
+ *     // Cache highlighted tokens...
+ *   }
+ *
+ *   getLineTokens(bufferId: string, row: number): Token[] {
+ *     // Return tokens for the line...
+ *   }
+ * }
+ * ```
  */
 
 import type {
@@ -10,6 +64,7 @@ import type {
   Point,
   Tree,
 } from "web-tree-sitter";
+import { detectLanguage, type LanguageId } from "./languages.ts";
 import { colorForNodeType } from "./theme.ts";
 
 export interface Token {
@@ -45,10 +100,73 @@ export function applyTreeEdit(tree: Tree, edit: TreeEdit): void {
   tree.edit(edit as import("web-tree-sitter").Edit);
 }
 
-/** Common interface for syntax highlighters. */
+/**
+ * Common interface for syntax highlighters.
+ *
+ * Implement this interface to provide custom syntax highlighting using
+ * alternative engines like Shiki, Prism, or TextMate grammars.
+ *
+ * The renderer calls {@link parseBuffer} when buffer content changes, then
+ * {@link getLineTokens} for each visible line during rendering.
+ *
+ * @example
+ * ```ts
+ * // Custom Shiki-based highlighter
+ * class ShikiHighlighter implements SyntaxHighlighter {
+ *   private _ready = false;
+ *   private _cache = new Map<string, Token[][]>();
+ *
+ *   get ready() { return this._ready; }
+ *
+ *   async init() {
+ *     // Initialize Shiki...
+ *     this._ready = true;
+ *   }
+ *
+ *   parseBuffer(bufferId: string, text: string): void {
+ *     // Highlight entire buffer and cache tokens by line
+ *     const highlighted = shiki.codeToTokens(text, { lang: 'typescript' });
+ *     this._cache.set(bufferId, highlighted.tokens);
+ *   }
+ *
+ *   getLineTokens(bufferId: string, row: number): Token[] {
+ *     const lines = this._cache.get(bufferId);
+ *     if (!lines || row >= lines.length) return [];
+ *     return lines[row].map(t => ({
+ *       startColumn: t.offset,
+ *       endColumn: t.offset + t.content.length,
+ *       color: t.color ?? 'inherit',
+ *     }));
+ *   }
+ * }
+ * ```
+ */
 export interface SyntaxHighlighter {
+  /** Whether the highlighter is initialized and ready to use. */
   readonly ready: boolean;
+
+  /**
+   * Parse or re-parse buffer content for syntax highlighting.
+   *
+   * Called by the renderer when buffer content changes. Implementations
+   * should cache the parse result for efficient {@link getLineTokens} calls.
+   *
+   * @param bufferId - Unique identifier for the buffer
+   * @param text - Full text content of the buffer
+   * @param edit - Optional incremental edit descriptor for tree-sitter
+   */
   parseBuffer(bufferId: string, text: string, edit?: TreeEdit): void;
+
+  /**
+   * Get syntax tokens for a specific line.
+   *
+   * Called by the renderer for each visible line during rendering.
+   * Tokens must be sorted by startColumn (ascending).
+   *
+   * @param bufferId - Buffer identifier passed to parseBuffer
+   * @param row - Zero-based line number
+   * @returns Array of tokens sorted by startColumn, or empty array if unavailable
+   */
   getLineTokens(bufferId: string, row: number): Token[];
 }
 
@@ -234,5 +352,339 @@ export function buildHighlightedSpans(
     const trailing = document.createElement("span");
     trailing.textContent = text.slice(pos);
     container.appendChild(trailing);
+  }
+}
+
+/**
+ * Configuration options for MultiLanguageHighlighter initialization.
+ */
+export interface MultiLanguageHighlighterOptions {
+  /**
+   * URL or path to the tree-sitter WASM runtime.
+   * This is the core tree-sitter.wasm file, not language-specific.
+   */
+  treeSitterWasmUrl: string;
+
+  /**
+   * Map of language IDs to their grammar WASM URLs.
+   *
+   * @example
+   * ```ts
+   * {
+   *   typescript: "/grammars/tree-sitter-typescript.wasm",
+   *   rust: "/grammars/tree-sitter-rust.wasm",
+   *   python: "/grammars/tree-sitter-python.wasm",
+   * }
+   * ```
+   */
+  languages: Partial<Record<LanguageId, string>>;
+}
+
+/**
+ * Multi-language syntax highlighter using tree-sitter.
+ *
+ * Supports loading multiple language grammars and selecting the appropriate
+ * one per buffer based on language ID or filename extension.
+ *
+ * @example
+ * ```ts
+ * const highlighter = new MultiLanguageHighlighter();
+ * await highlighter.init({
+ *   treeSitterWasmUrl: "/wasm/tree-sitter.wasm",
+ *   languages: {
+ *     typescript: "/grammars/tree-sitter-typescript.wasm",
+ *     rust: "/grammars/tree-sitter-rust.wasm",
+ *   },
+ * });
+ *
+ * // Explicit language
+ * highlighter.parseBuffer("file.ts", code, undefined, "typescript");
+ *
+ * // Auto-detect from path
+ * highlighter.parseBufferWithPath("src/main.rs", rustCode);
+ * ```
+ */
+export class MultiLanguageHighlighter implements SyntaxHighlighter {
+  private _parser: ParserType | null = null;
+  private _languages = new Map<LanguageId, Language>();
+  private _trees = new Map<string, Tree>();
+  private _bufferLanguages = new Map<string, LanguageId>();
+  private _ready = false;
+  private _pendingLoads = new Map<LanguageId, Promise<Language | null>>();
+  private _languageUrls: Partial<Record<LanguageId, string>> = {};
+  private _LangClass: typeof Language | null = null;
+
+  get ready(): boolean {
+    return this._ready;
+  }
+
+  /**
+   * Get the set of currently loaded language IDs.
+   */
+  get loadedLanguages(): ReadonlySet<LanguageId> {
+    return new Set(this._languages.keys());
+  }
+
+  /**
+   * Initialize the highlighter with the tree-sitter runtime and language grammars.
+   *
+   * @param options - Configuration with tree-sitter URL and language grammar URLs
+   */
+  async init(options: MultiLanguageHighlighterOptions): Promise<void> {
+    const { treeSitterWasmUrl, languages } = options;
+
+    const mod = await import("web-tree-sitter");
+    const Parser = mod.Parser ?? mod.default;
+    await Parser.init({
+      locateFile: () => treeSitterWasmUrl,
+    });
+
+    this._parser = new Parser();
+    this._LangClass =
+      mod.Language ??
+      // biome-ignore lint/plugin/no-type-assertion: expect: Language is exported at module level but also accessible via Parser
+      (Parser as unknown as { Language: typeof Language }).Language;
+
+    this._languageUrls = languages;
+
+    // Load all configured languages
+    const loadPromises = Object.entries(languages).map(async ([langId, url]) => {
+      if (url) {
+        // biome-ignore lint/plugin/no-type-assertion: expect: Object.entries loses key typing, langId is a valid LanguageId key
+        await this._loadLanguage(langId as LanguageId, url);
+      }
+    });
+
+    await Promise.all(loadPromises);
+    this._ready = true;
+  }
+
+  /**
+   * Load a language grammar dynamically.
+   *
+   * Use this to add language support after initialization, or to lazy-load
+   * grammars on demand.
+   *
+   * @param languageId - Language identifier
+   * @param wasmUrl - URL or path to the grammar WASM file
+   * @returns Promise resolving when the language is loaded
+   */
+  async loadLanguage(languageId: LanguageId, wasmUrl: string): Promise<void> {
+    this._languageUrls[languageId] = wasmUrl;
+    await this._loadLanguage(languageId, wasmUrl);
+  }
+
+  private async _loadLanguage(languageId: LanguageId, wasmUrl: string): Promise<Language | null> {
+    // Return existing language if already loaded
+    const existing = this._languages.get(languageId);
+    if (existing) return existing;
+
+    // Return pending promise if already loading
+    const pending = this._pendingLoads.get(languageId);
+    if (pending) return pending;
+
+    // Start loading
+    const loadPromise = (async () => {
+      try {
+        if (!this._LangClass) return null;
+        const language = await this._LangClass.load(wasmUrl);
+        this._languages.set(languageId, language);
+        return language;
+      } catch (e) {
+        console.warn(`Failed to load language "${languageId}" from ${wasmUrl}:`, e);
+        return null;
+      } finally {
+        this._pendingLoads.delete(languageId);
+      }
+    })();
+
+    this._pendingLoads.set(languageId, loadPromise);
+    return loadPromise;
+  }
+
+  /**
+   * Check if a language grammar is loaded and available.
+   */
+  hasLanguage(languageId: LanguageId): boolean {
+    return this._languages.has(languageId);
+  }
+
+  /**
+   * Parse a buffer with an explicit language ID.
+   *
+   * @param bufferId - Unique identifier for the buffer
+   * @param text - Full text content
+   * @param edit - Optional incremental edit descriptor
+   * @param languageId - Language to use for parsing (optional, uses last known or plaintext)
+   */
+  parseBuffer(bufferId: string, text: string, edit?: TreeEdit, languageId?: LanguageId): void {
+    if (!this._parser) return;
+
+    // Determine language: explicit > previously set > plaintext
+    const lang = languageId ?? this._bufferLanguages.get(bufferId) ?? "plaintext";
+
+    // Store the language for this buffer
+    if (languageId) {
+      this._bufferLanguages.set(bufferId, languageId);
+    }
+
+    // Get the language grammar
+    const language = this._languages.get(lang);
+    if (!language) {
+      // No grammar available - clear any existing tree
+      this._trees.delete(bufferId);
+      return;
+    }
+
+    // Set the parser language
+    this._parser.setLanguage(language);
+
+    // Parse with optional incremental edit
+    const oldTree = this._trees.get(bufferId);
+    if (oldTree && edit) {
+      applyTreeEdit(oldTree, edit);
+    }
+
+    const tree = this._parser.parse(text, oldTree);
+    if (tree) {
+      this._trees.set(bufferId, tree);
+    } else if (oldTree && edit) {
+      this._trees.delete(bufferId);
+    }
+  }
+
+  /**
+   * Parse a buffer, auto-detecting language from the file path.
+   *
+   * @param path - File path used for language detection (e.g., "src/main.rs")
+   * @param text - Full text content
+   * @param edit - Optional incremental edit descriptor
+   */
+  parseBufferWithPath(path: string, text: string, edit?: TreeEdit): void {
+    const languageId = detectLanguage(path);
+    this.parseBuffer(path, text, edit, languageId);
+  }
+
+  /**
+   * Set the language for a buffer without re-parsing.
+   * Call parseBuffer after this to apply the language.
+   */
+  setBufferLanguage(bufferId: string, languageId: LanguageId): void {
+    this._bufferLanguages.set(bufferId, languageId);
+  }
+
+  /**
+   * Get the language ID currently associated with a buffer.
+   */
+  getBufferLanguage(bufferId: string): LanguageId | undefined {
+    return this._bufferLanguages.get(bufferId);
+  }
+
+  /**
+   * Get syntax tokens for a specific line of a buffer.
+   * Returns tokens in startColumn order (guaranteed by depth-first tree traversal).
+   */
+  getLineTokens(bufferId: string, row: number): Token[] {
+    const tree = this._trees.get(bufferId);
+    if (!tree) return [];
+
+    const tokens: Token[] = [];
+    this._collectTokens(tree.rootNode, row, tokens, null);
+    return tokens;
+  }
+
+  /** Node types that should not have their children highlighted (code injections). */
+  private static readonly SKIP_CHILDREN = new Set([
+    "fenced_code_block",
+    "indented_code_block",
+    "code_span",
+  ]);
+
+  /** Node types that propagate their styling to all children. */
+  private static readonly STYLED_PARENTS = new Set([
+    "atx_heading",
+    "setext_heading",
+    "emphasis",
+    "strong_emphasis",
+    "strikethrough",
+    "link_text",
+    "inline_link",
+    "shortcut_link",
+  ]);
+
+  private _collectTokens(
+    node: Node,
+    targetRow: number,
+    tokens: Token[],
+    inheritedColor: string | null,
+  ): void {
+    if (
+      node.endPosition.row < targetRow ||
+      node.startPosition.row > targetRow
+    ) {
+      return;
+    }
+
+    const nodeType = node.type;
+
+    // Skip highlighting inside code blocks - just use default color for the whole range
+    if (MultiLanguageHighlighter.SKIP_CHILDREN.has(nodeType)) {
+      const startCol =
+        node.startPosition.row === targetRow ? node.startPosition.column : 0;
+      const endCol =
+        node.endPosition.row === targetRow
+          ? node.endPosition.column
+          : Number.MAX_SAFE_INTEGER;
+      if (startCol < endCol) {
+        tokens.push({
+          startColumn: startCol,
+          endColumn: endCol,
+          color: colorForNodeType("fenced_code_block_delimiter"),
+        });
+      }
+      return;
+    }
+
+    // Determine if this node should propagate its color to children
+    let colorToPropagate = inheritedColor;
+    if (MultiLanguageHighlighter.STYLED_PARENTS.has(nodeType)) {
+      colorToPropagate = colorForNodeType(nodeType);
+    }
+
+    // Leaf node - apply color
+    if (node.childCount === 0) {
+      const startCol =
+        node.startPosition.row === targetRow ? node.startPosition.column : 0;
+      const endCol =
+        node.endPosition.row === targetRow
+          ? node.endPosition.column
+          : Number.MAX_SAFE_INTEGER;
+
+      if (startCol < endCol) {
+        const color = colorToPropagate ?? colorForNodeType(nodeType);
+        tokens.push({
+          startColumn: startCol,
+          endColumn: endCol,
+          color,
+        });
+      }
+      return;
+    }
+
+    // Recurse into children
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child) {
+        this._collectTokens(child, targetRow, tokens, colorToPropagate);
+      }
+    }
+  }
+
+  /**
+   * Remove a buffer's parse tree and language association.
+   */
+  removeBuffer(bufferId: string): void {
+    this._trees.delete(bufferId);
+    this._bufferLanguages.delete(bufferId);
   }
 }

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,10 +1,12 @@
 export { createDomRenderer, DomRenderer } from "./dom.ts";
-export type { SyntaxHighlighter, Token, TreeEdit } from "./highlighter.ts";
-export { buildHighlightedSpans, Highlighter } from "./highlighter.ts";
+export type { MultiLanguageHighlighterOptions, SyntaxHighlighter, Token, TreeEdit } from "./highlighter.ts";
+export { buildHighlightedSpans, Highlighter, MultiLanguageHighlighter } from "./highlighter.ts";
 export {
   buildHighlightedSpans as buildHighlightedSpansWithInjection,
   InjectionHighlighter,
 } from "./injection-highlighter.ts";
+export type { LanguageConfig, LanguageId } from "./languages.ts";
+export { DEFAULT_GRAMMAR_URLS, detectLanguage, getGrammarName, isLanguageSupported } from "./languages.ts";
 export {
   calculateContentHeight,
   calculateVisibleRows,

--- a/src/renderer/languages.ts
+++ b/src/renderer/languages.ts
@@ -1,0 +1,235 @@
+/**
+ * Language detection and configuration for syntax highlighting.
+ *
+ * Maps file extensions to language IDs and provides metadata about
+ * supported languages for tree-sitter grammar loading.
+ */
+
+/** Supported language identifiers. */
+export type LanguageId =
+  | "typescript"
+  | "tsx"
+  | "javascript"
+  | "jsx"
+  | "rust"
+  | "go"
+  | "python"
+  | "ruby"
+  | "html"
+  | "css"
+  | "json"
+  | "yaml"
+  | "toml"
+  | "bash"
+  | "markdown"
+  | "c"
+  | "cpp"
+  | "java"
+  | "swift"
+  | "kotlin"
+  | "zig"
+  | "lua"
+  | "sql"
+  | "dockerfile"
+  | "plaintext";
+
+/**
+ * Map of file extensions to language IDs.
+ * Extensions are lowercase without the leading dot.
+ */
+const EXTENSION_TO_LANGUAGE: ReadonlyMap<string, LanguageId> = new Map([
+  // TypeScript / JavaScript
+  ["ts", "typescript"],
+  ["tsx", "tsx"],
+  ["mts", "typescript"],
+  ["cts", "typescript"],
+  ["js", "javascript"],
+  ["jsx", "jsx"],
+  ["mjs", "javascript"],
+  ["cjs", "javascript"],
+
+  // Rust
+  ["rs", "rust"],
+
+  // Go
+  ["go", "go"],
+
+  // Python
+  ["py", "python"],
+  ["pyi", "python"],
+  ["pyw", "python"],
+
+  // Ruby
+  ["rb", "ruby"],
+  ["rake", "ruby"],
+  ["gemspec", "ruby"],
+
+  // Web
+  ["html", "html"],
+  ["htm", "html"],
+  ["xhtml", "html"],
+  ["css", "css"],
+  ["scss", "css"],
+  ["sass", "css"],
+
+  // Data formats
+  ["json", "json"],
+  ["jsonc", "json"],
+  ["yaml", "yaml"],
+  ["yml", "yaml"],
+  ["toml", "toml"],
+
+  // Shell
+  ["sh", "bash"],
+  ["bash", "bash"],
+  ["zsh", "bash"],
+  ["fish", "bash"],
+
+  // Markdown
+  ["md", "markdown"],
+  ["mdx", "markdown"],
+  ["markdown", "markdown"],
+
+  // C / C++
+  ["c", "c"],
+  ["h", "c"],
+  ["cc", "cpp"],
+  ["cpp", "cpp"],
+  ["cxx", "cpp"],
+  ["hpp", "cpp"],
+  ["hxx", "cpp"],
+
+  // Java
+  ["java", "java"],
+
+  // Swift
+  ["swift", "swift"],
+
+  // Kotlin
+  ["kt", "kotlin"],
+  ["kts", "kotlin"],
+
+  // Zig
+  ["zig", "zig"],
+
+  // Lua
+  ["lua", "lua"],
+
+  // SQL
+  ["sql", "sql"],
+
+  // Docker
+  ["dockerfile", "dockerfile"],
+]);
+
+/**
+ * Map of special filenames (case-insensitive) to language IDs.
+ */
+const FILENAME_TO_LANGUAGE: ReadonlyMap<string, LanguageId> = new Map([
+  ["dockerfile", "dockerfile"],
+  ["makefile", "bash"],
+  ["gemfile", "ruby"],
+  ["rakefile", "ruby"],
+  ["cmakelists.txt", "bash"],
+  [".bashrc", "bash"],
+  [".zshrc", "bash"],
+  [".profile", "bash"],
+  [".bash_profile", "bash"],
+  [".gitignore", "plaintext"],
+  [".env", "bash"],
+]);
+
+/**
+ * Detect language ID from a file path or filename.
+ *
+ * Detection order:
+ * 1. Special filename matches (Dockerfile, Makefile, etc.)
+ * 2. File extension
+ * 3. Falls back to "plaintext" if no match
+ *
+ * @param path - File path or filename (e.g., "src/main.rs", "Dockerfile")
+ * @returns The detected language ID
+ *
+ * @example
+ * ```ts
+ * detectLanguage("src/lib.rs")      // "rust"
+ * detectLanguage("package.json")    // "json"
+ * detectLanguage("Dockerfile")      // "dockerfile"
+ * detectLanguage("unknown.xyz")     // "plaintext"
+ * ```
+ */
+export function detectLanguage(path: string): LanguageId {
+  // Extract filename from path
+  const filename = path.split("/").pop() ?? path;
+  const lowerFilename = filename.toLowerCase();
+
+  // Check special filenames first
+  const filenameMatch = FILENAME_TO_LANGUAGE.get(lowerFilename);
+  if (filenameMatch) {
+    return filenameMatch;
+  }
+
+  // Extract and check extension
+  const lastDot = filename.lastIndexOf(".");
+  if (lastDot !== -1) {
+    const ext = filename.slice(lastDot + 1).toLowerCase();
+    const extMatch = EXTENSION_TO_LANGUAGE.get(ext);
+    if (extMatch) {
+      return extMatch;
+    }
+  }
+
+  return "plaintext";
+}
+
+/**
+ * Check if a language ID has tree-sitter grammar support.
+ * "plaintext" is always unsupported (no syntax highlighting).
+ */
+export function isLanguageSupported(languageId: LanguageId): boolean {
+  return languageId !== "plaintext";
+}
+
+/**
+ * Get the canonical tree-sitter grammar name for a language ID.
+ * Some languages share grammars (e.g., tsx uses typescript grammar with TSX dialect).
+ *
+ * @returns The grammar name, or null if the language has no grammar
+ */
+export function getGrammarName(languageId: LanguageId): string | null {
+  switch (languageId) {
+    case "typescript":
+    case "tsx":
+      return "typescript";
+    case "javascript":
+    case "jsx":
+      return "javascript";
+    case "plaintext":
+      return null;
+    default:
+      return languageId;
+  }
+}
+
+/**
+ * Configuration for loading language grammars.
+ * Used by the multi-language highlighter.
+ */
+export interface LanguageConfig {
+  /** Language identifier */
+  id: LanguageId;
+  /** URL or path to the tree-sitter WASM grammar file */
+  wasmUrl: string;
+}
+
+/**
+ * Default grammar URLs using CDN paths.
+ * Consumers can override these when initializing the highlighter.
+ */
+export const DEFAULT_GRAMMAR_URLS: Partial<Record<LanguageId, string>> = {
+  // These are example paths - consumers should provide their own URLs
+  // typescript: "/grammars/tree-sitter-typescript.wasm",
+  // javascript: "/grammars/tree-sitter-javascript.wasm",
+  // rust: "/grammars/tree-sitter-rust.wasm",
+  // etc.
+};

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -183,6 +183,413 @@ const NODE_TYPE_CATEGORY: ReadonlyMap<string, string> = new Map([
   ["anchor_name", "type"], ["alias_name", "type"], ["tag", "type"],
   // Escape sequences
   ["escape_sequence", "operator"],
+
+  // ── Rust ────────────────────────────────────────────────────────────
+  // Keywords
+  ["fn", "keyword"], ["let", "keyword"], ["mut", "keyword"],
+  ["pub", "keyword"], ["mod", "keyword"], ["use", "keyword"],
+  ["struct", "keyword"], ["impl", "keyword"], ["trait", "keyword"],
+  ["where", "keyword"], ["self", "keyword"], ["Self", "type"],
+  ["crate", "keyword"], ["extern", "keyword"], ["unsafe", "keyword"],
+  ["async", "keyword"], ["await", "keyword"], ["move", "keyword"],
+  ["ref", "keyword"], ["match", "keyword"], ["loop", "keyword"],
+  ["dyn", "keyword"], ["const", "keyword"], ["static", "keyword"],
+  ["enum", "keyword"], ["union", "keyword"], ["type", "keyword"],
+  ["as", "keyword"], ["impl", "keyword"], ["macro_rules!", "keyword"],
+  // Types
+  ["primitive_type", "type"], ["type_identifier", "type"],
+  ["generic_type", "type"], ["scoped_type_identifier", "type"],
+  // Strings and chars
+  ["string_literal", "string"], ["char_literal", "string"],
+  ["raw_string_literal", "string"],
+  // Numbers
+  ["integer_literal", "number"], ["float_literal", "number"],
+  // Booleans
+  ["boolean_literal", "constant"],
+  // Lifetime
+  ["lifetime", "type"],
+  // Attributes
+  ["attribute_item", "comment"], ["inner_attribute_item", "comment"],
+  // Macros
+  ["macro_invocation", "function"],
+  ["identifier", "default"], ["field_identifier", "property"],
+  ["scoped_identifier", "default"],
+
+  // ── Go ──────────────────────────────────────────────────────────────
+  // Keywords
+  ["func", "keyword"], ["package", "keyword"], ["import", "keyword"],
+  ["go", "keyword"], ["defer", "keyword"], ["chan", "keyword"],
+  ["select", "keyword"], ["fallthrough", "keyword"], ["range", "keyword"],
+  ["map", "keyword"], ["struct", "keyword"], ["interface", "keyword"],
+  // Types
+  ["type_identifier", "type"], ["qualified_type", "type"],
+  ["pointer_type", "type"], ["slice_type", "type"], ["array_type", "type"],
+  ["map_type", "type"], ["channel_type", "type"],
+  // Strings
+  ["raw_string_literal", "string"], ["interpreted_string_literal", "string"],
+  ["rune_literal", "string"],
+  // Numbers
+  ["int_literal", "number"], ["float_literal", "number"],
+  ["imaginary_literal", "number"],
+  // Booleans and nil
+  ["true", "constant"], ["false", "constant"], ["nil", "constant"],
+  ["iota", "constant"],
+  // Fields
+  ["field_identifier", "property"],
+
+  // ── Python ──────────────────────────────────────────────────────────
+  // Keywords
+  ["def", "keyword"], ["class", "keyword"], ["lambda", "keyword"],
+  ["pass", "keyword"], ["nonlocal", "keyword"], ["global", "keyword"],
+  ["with", "keyword"], ["as", "keyword"], ["from", "keyword"],
+  ["import", "keyword"], ["assert", "keyword"], ["raise", "keyword"],
+  ["except", "keyword"], ["finally", "keyword"], ["is", "keyword"],
+  ["not", "keyword"], ["and", "keyword"], ["or", "keyword"],
+  ["in", "keyword"], ["del", "keyword"], ["print", "keyword"],
+  ["exec", "keyword"], ["async", "keyword"], ["await", "keyword"],
+  // Identifiers (Python-specific node types use more specific names)
+  ["identifier", "default"],
+  // Strings
+  ["string", "string"], ["concatenated_string", "string"],
+  ["string_content", "string"], ["interpolation", "string"],
+  // Numbers
+  ["integer", "number"], ["float", "number"],
+  // Booleans and None
+  ["True", "constant"], ["False", "constant"], ["None", "constant"],
+  // Decorators
+  ["decorator", "function"],
+  // Self
+  ["self", "variable_builtin"],
+  // Attribute
+  ["attribute", "property"],
+
+  // ── Ruby ────────────────────────────────────────────────────────────
+  // Keywords
+  ["def", "keyword"], ["end", "keyword"], ["class", "keyword"],
+  ["module", "keyword"], ["begin", "keyword"], ["rescue", "keyword"],
+  ["ensure", "keyword"], ["raise", "keyword"], ["yield", "keyword"],
+  ["alias", "keyword"], ["undef", "keyword"], ["defined?", "keyword"],
+  ["BEGIN", "keyword"], ["END", "keyword"], ["__FILE__", "constant"],
+  ["__LINE__", "constant"], ["__ENCODING__", "constant"],
+  // Strings
+  ["string", "string"], ["subshell", "string"],
+  ["heredoc_beginning", "string"], ["heredoc_end", "string"],
+  ["heredoc_body", "string"], ["heredoc_content", "string"],
+  ["string_content", "string"],
+  // Symbols
+  ["symbol", "constant"], ["simple_symbol", "constant"],
+  ["hash_key_symbol", "constant"],
+  // Numbers
+  ["integer", "number"], ["float", "number"], ["rational", "number"],
+  ["complex", "number"],
+  // Booleans and nil
+  ["true", "constant"], ["false", "constant"], ["nil", "constant"],
+  // Instance/class variables
+  ["instance_variable", "variable_builtin"],
+  ["class_variable", "variable_builtin"],
+  ["global_variable", "variable_builtin"],
+  // Regex
+  ["regex", "string"],
+
+  // ── HTML ────────────────────────────────────────────────────────────
+  // Tags
+  ["tag_name", "keyword"], ["start_tag", "keyword"], ["end_tag", "keyword"],
+  ["self_closing_tag", "keyword"],
+  // Attributes
+  ["attribute_name", "property"], ["attribute_value", "string"],
+  ["quoted_attribute_value", "string"],
+  // Text
+  ["text", "default"], ["raw_text", "default"],
+  // Special
+  ["doctype", "comment"], ["comment", "comment"],
+  ["erroneous_end_tag_name", "keyword"],
+
+  // ── CSS ─────────────────────────────────────────────────────────────
+  // Selectors
+  ["tag_name", "keyword"], ["class_name", "type"],
+  ["id_name", "constant"], ["attribute_name", "property"],
+  ["pseudo_class_selector", "function"], ["pseudo_element_selector", "function"],
+  // Properties
+  ["property_name", "property"], ["feature_name", "property"],
+  // Values
+  ["plain_value", "default"], ["color_value", "constant"],
+  ["integer_value", "number"], ["float_value", "number"],
+  ["string_value", "string"], ["unit", "keyword"],
+  // Functions
+  ["function_name", "function"], ["call_expression", "function"],
+  // At-rules
+  ["at_keyword", "keyword"], ["keyword_query", "keyword"],
+  // Important
+  ["important", "keyword"],
+
+  // ── JSON ────────────────────────────────────────────────────────────
+  // Strings (keys and values)
+  ["string", "string"], ["string_content", "string"],
+  ["pair", "default"],
+  // Numbers
+  ["number", "number"],
+  // Booleans and null
+  ["true", "constant"], ["false", "constant"], ["null", "constant"],
+  // Escape sequences
+  ["escape_sequence", "operator"],
+
+  // ── TOML ────────────────────────────────────────────────────────────
+  // Keys
+  ["bare_key", "property"], ["dotted_key", "property"],
+  ["quoted_key", "property"],
+  // Strings
+  ["string", "string"], ["basic_string", "string"],
+  ["literal_string", "string"], ["multiline_basic_string", "string"],
+  ["multiline_literal_string", "string"],
+  // Numbers
+  ["integer", "number"], ["float", "number"],
+  ["local_date", "number"], ["local_time", "number"],
+  ["local_date_time", "number"], ["offset_date_time", "number"],
+  // Booleans
+  ["boolean", "constant"],
+  // Tables
+  ["table", "keyword"], ["table_array_element", "keyword"],
+
+  // ── Bash / Shell ────────────────────────────────────────────────────
+  // Commands
+  ["command_name", "function"], ["function_definition", "function"],
+  // Variables
+  ["variable_name", "variable_builtin"], ["special_variable_name", "variable_builtin"],
+  ["simple_expansion", "variable_builtin"], ["expansion", "variable_builtin"],
+  // Strings
+  ["string", "string"], ["raw_string", "string"],
+  ["ansi_c_string", "string"], ["heredoc_body", "string"],
+  ["string_content", "string"],
+  // Numbers
+  ["number", "number"],
+  // Keywords
+  ["if", "keyword"], ["then", "keyword"], ["else", "keyword"],
+  ["elif", "keyword"], ["fi", "keyword"], ["case", "keyword"],
+  ["esac", "keyword"], ["for", "keyword"], ["while", "keyword"],
+  ["until", "keyword"], ["do", "keyword"], ["done", "keyword"],
+  ["in", "keyword"], ["function", "keyword"],
+  // Operators
+  ["test_operator", "operator"], ["regex", "string"],
+  // Comments
+  ["comment", "comment"],
+
+  // ── C / C++ ─────────────────────────────────────────────────────────
+  // Keywords
+  ["sizeof", "keyword"], ["typedef", "keyword"], ["struct", "keyword"],
+  ["union", "keyword"], ["enum", "keyword"], ["extern", "keyword"],
+  ["static", "keyword"], ["register", "keyword"], ["volatile", "keyword"],
+  ["inline", "keyword"], ["restrict", "keyword"], ["_Atomic", "keyword"],
+  ["_Bool", "keyword"], ["_Complex", "keyword"], ["_Imaginary", "keyword"],
+  // C++ specific
+  ["namespace", "keyword"], ["template", "keyword"], ["typename", "keyword"],
+  ["virtual", "keyword"], ["explicit", "keyword"], ["friend", "keyword"],
+  ["mutable", "keyword"], ["constexpr", "keyword"], ["consteval", "keyword"],
+  ["constinit", "keyword"], ["concept", "keyword"], ["requires", "keyword"],
+  ["co_await", "keyword"], ["co_return", "keyword"], ["co_yield", "keyword"],
+  ["noexcept", "keyword"], ["nullptr", "constant"],
+  // Types
+  ["primitive_type", "type"], ["type_identifier", "type"],
+  ["sized_type_specifier", "type"], ["type_qualifier", "keyword"],
+  // Strings
+  ["string_literal", "string"], ["char_literal", "string"],
+  ["raw_string_literal", "string"], ["system_lib_string", "string"],
+  // Numbers
+  ["number_literal", "number"],
+  // Preprocessor
+  ["preproc_directive", "keyword"], ["preproc_include", "keyword"],
+  ["preproc_def", "keyword"], ["preproc_ifdef", "keyword"],
+  ["preproc_else", "keyword"], ["preproc_elif", "keyword"],
+  ["preproc_if", "keyword"], ["preproc_defined", "keyword"],
+  // Fields
+  ["field_identifier", "property"],
+
+  // ── Java ────────────────────────────────────────────────────────────
+  // Keywords
+  ["package", "keyword"], ["import", "keyword"], ["class", "keyword"],
+  ["interface", "keyword"], ["extends", "keyword"], ["implements", "keyword"],
+  ["public", "keyword"], ["private", "keyword"], ["protected", "keyword"],
+  ["static", "keyword"], ["final", "keyword"], ["abstract", "keyword"],
+  ["synchronized", "keyword"], ["volatile", "keyword"], ["transient", "keyword"],
+  ["native", "keyword"], ["strictfp", "keyword"], ["throws", "keyword"],
+  ["instanceof", "keyword"], ["assert", "keyword"],
+  // Types
+  ["type_identifier", "type"], ["generic_type", "type"],
+  ["scoped_type_identifier", "type"], ["integral_type", "type"],
+  ["floating_point_type", "type"], ["boolean_type", "type"],
+  ["void_type", "type"],
+  // Strings
+  ["string_literal", "string"], ["character_literal", "string"],
+  ["text_block", "string"],
+  // Numbers
+  ["decimal_integer_literal", "number"], ["hex_integer_literal", "number"],
+  ["octal_integer_literal", "number"], ["binary_integer_literal", "number"],
+  ["decimal_floating_point_literal", "number"], ["hex_floating_point_literal", "number"],
+  // Booleans and null
+  ["true", "constant"], ["false", "constant"], ["null_literal", "constant"],
+  // Annotations
+  ["annotation", "function"], ["marker_annotation", "function"],
+  // This/super
+  ["this", "variable_builtin"], ["super", "variable_builtin"],
+
+  // ── Kotlin ──────────────────────────────────────────────────────────
+  // Keywords
+  ["fun", "keyword"], ["val", "keyword"], ["var", "keyword"],
+  ["object", "keyword"], ["companion", "keyword"], ["data", "keyword"],
+  ["sealed", "keyword"], ["inner", "keyword"], ["open", "keyword"],
+  ["lateinit", "keyword"], ["by", "keyword"], ["where", "keyword"],
+  ["suspend", "keyword"], ["inline", "keyword"], ["noinline", "keyword"],
+  ["crossinline", "keyword"], ["reified", "keyword"], ["tailrec", "keyword"],
+  ["operator", "keyword"], ["infix", "keyword"], ["external", "keyword"],
+  ["annotation", "keyword"], ["actual", "keyword"], ["expect", "keyword"],
+  // Types
+  ["type_identifier", "type"], ["user_type", "type"],
+  // Strings
+  ["line_string_literal", "string"], ["multi_line_string_literal", "string"],
+  ["character_literal", "string"],
+  // Numbers
+  ["integer_literal", "number"], ["long_literal", "number"],
+  ["hex_literal", "number"], ["bin_literal", "number"],
+  ["real_literal", "number"],
+  // Booleans and null
+  ["boolean_literal", "constant"], ["null", "constant"],
+  // This/super
+  ["this", "variable_builtin"], ["super", "variable_builtin"],
+
+  // ── Swift ───────────────────────────────────────────────────────────
+  // Keywords
+  ["func", "keyword"], ["let", "keyword"], ["var", "keyword"],
+  ["class", "keyword"], ["struct", "keyword"], ["enum", "keyword"],
+  ["protocol", "keyword"], ["extension", "keyword"], ["typealias", "keyword"],
+  ["import", "keyword"], ["init", "keyword"], ["deinit", "keyword"],
+  ["get", "keyword"], ["set", "keyword"], ["willSet", "keyword"],
+  ["didSet", "keyword"], ["subscript", "keyword"], ["static", "keyword"],
+  ["class", "keyword"], ["final", "keyword"], ["mutating", "keyword"],
+  ["nonmutating", "keyword"], ["lazy", "keyword"], ["weak", "keyword"],
+  ["unowned", "keyword"], ["required", "keyword"], ["optional", "keyword"],
+  ["indirect", "keyword"], ["infix", "keyword"], ["prefix", "keyword"],
+  ["postfix", "keyword"], ["precedence", "keyword"], ["associativity", "keyword"],
+  ["operator", "keyword"], ["async", "keyword"], ["await", "keyword"],
+  ["actor", "keyword"], ["isolated", "keyword"], ["nonisolated", "keyword"],
+  // Types
+  ["type_identifier", "type"], ["simple_identifier", "default"],
+  // Strings
+  ["line_str_text", "string"], ["multi_line_string_literal", "string"],
+  ["string_literal", "string"],
+  // Numbers
+  ["integer_literal", "number"], ["real_literal", "number"],
+  // Booleans and nil
+  ["boolean_literal", "constant"], ["nil", "constant"],
+  // Self
+  ["self", "variable_builtin"], ["Self", "type"],
+
+  // ── Zig ─────────────────────────────────────────────────────────────
+  // Keywords
+  ["fn", "keyword"], ["const", "keyword"], ["var", "keyword"],
+  ["pub", "keyword"], ["comptime", "keyword"], ["inline", "keyword"],
+  ["noinline", "keyword"], ["extern", "keyword"], ["export", "keyword"],
+  ["linksection", "keyword"], ["align", "keyword"], ["callconv", "keyword"],
+  ["packed", "keyword"], ["struct", "keyword"], ["enum", "keyword"],
+  ["union", "keyword"], ["opaque", "keyword"], ["error", "keyword"],
+  ["orelse", "keyword"], ["catch", "keyword"], ["unreachable", "keyword"],
+  ["nosuspend", "keyword"], ["noasync", "keyword"], ["suspend", "keyword"],
+  ["resume", "keyword"], ["async", "keyword"], ["await", "keyword"],
+  ["try", "keyword"], ["anyframe", "keyword"], ["anytype", "keyword"],
+  ["threadlocal", "keyword"], ["test", "keyword"], ["usingnamespace", "keyword"],
+  // Types
+  ["identifier", "default"], ["builtin_type", "type"],
+  // Strings
+  ["string_literal", "string"], ["multiline_string_literal", "string"],
+  ["char_literal", "string"],
+  // Numbers
+  ["integer_literal", "number"], ["float_literal", "number"],
+  // Booleans and null
+  ["true", "constant"], ["false", "constant"], ["null", "constant"],
+  ["undefined", "constant"],
+
+  // ── Lua ─────────────────────────────────────────────────────────────
+  // Keywords
+  ["function", "keyword"], ["local", "keyword"], ["end", "keyword"],
+  ["do", "keyword"], ["then", "keyword"], ["elseif", "keyword"],
+  ["repeat", "keyword"], ["until", "keyword"], ["goto", "keyword"],
+  ["in", "keyword"], ["not", "keyword"], ["and", "keyword"], ["or", "keyword"],
+  // Strings
+  ["string", "string"],
+  // Numbers
+  ["number", "number"],
+  // Booleans and nil
+  ["true", "constant"], ["false", "constant"], ["nil", "constant"],
+  // Self
+  ["self", "variable_builtin"],
+
+  // ── SQL ─────────────────────────────────────────────────────────────
+  // Keywords
+  ["select", "keyword"], ["SELECT", "keyword"],
+  ["from", "keyword"], ["FROM", "keyword"],
+  ["where", "keyword"], ["WHERE", "keyword"],
+  ["insert", "keyword"], ["INSERT", "keyword"],
+  ["update", "keyword"], ["UPDATE", "keyword"],
+  ["delete", "keyword"], ["DELETE", "keyword"],
+  ["create", "keyword"], ["CREATE", "keyword"],
+  ["drop", "keyword"], ["DROP", "keyword"],
+  ["alter", "keyword"], ["ALTER", "keyword"],
+  ["table", "keyword"], ["TABLE", "keyword"],
+  ["index", "keyword"], ["INDEX", "keyword"],
+  ["join", "keyword"], ["JOIN", "keyword"],
+  ["inner", "keyword"], ["INNER", "keyword"],
+  ["outer", "keyword"], ["OUTER", "keyword"],
+  ["left", "keyword"], ["LEFT", "keyword"],
+  ["right", "keyword"], ["RIGHT", "keyword"],
+  ["on", "keyword"], ["ON", "keyword"],
+  ["group", "keyword"], ["GROUP", "keyword"],
+  ["by", "keyword"], ["BY", "keyword"],
+  ["order", "keyword"], ["ORDER", "keyword"],
+  ["having", "keyword"], ["HAVING", "keyword"],
+  ["limit", "keyword"], ["LIMIT", "keyword"],
+  ["offset", "keyword"], ["OFFSET", "keyword"],
+  ["union", "keyword"], ["UNION", "keyword"],
+  ["all", "keyword"], ["ALL", "keyword"],
+  ["distinct", "keyword"], ["DISTINCT", "keyword"],
+  ["as", "keyword"], ["AS", "keyword"],
+  ["and", "keyword"], ["AND", "keyword"],
+  ["or", "keyword"], ["OR", "keyword"],
+  ["not", "keyword"], ["NOT", "keyword"],
+  ["null", "constant"], ["NULL", "constant"],
+  ["true", "constant"], ["TRUE", "constant"],
+  ["false", "constant"], ["FALSE", "constant"],
+  // Types (SQL-specific type keywords)
+  ["keyword_int", "type"], ["keyword_varchar", "type"],
+  // Strings
+  ["string", "string"], ["literal", "string"],
+  // Numbers
+  ["number", "number"],
+  // Functions
+  ["function_name", "function"],
+
+  // ── Dockerfile ──────────────────────────────────────────────────────
+  // Instructions
+  ["instruction", "keyword"],
+  ["from_instruction", "keyword"], ["FROM", "keyword"],
+  ["run_instruction", "keyword"], ["RUN", "keyword"],
+  ["cmd_instruction", "keyword"], ["CMD", "keyword"],
+  ["label_instruction", "keyword"], ["LABEL", "keyword"],
+  ["expose_instruction", "keyword"], ["EXPOSE", "keyword"],
+  ["env_instruction", "keyword"], ["ENV", "keyword"],
+  ["add_instruction", "keyword"], ["ADD", "keyword"],
+  ["copy_instruction", "keyword"], ["COPY", "keyword"],
+  ["entrypoint_instruction", "keyword"], ["ENTRYPOINT", "keyword"],
+  ["volume_instruction", "keyword"], ["VOLUME", "keyword"],
+  ["user_instruction", "keyword"], ["USER", "keyword"],
+  ["workdir_instruction", "keyword"], ["WORKDIR", "keyword"],
+  ["arg_instruction", "keyword"], ["ARG", "keyword"],
+  ["onbuild_instruction", "keyword"], ["ONBUILD", "keyword"],
+  ["stopsignal_instruction", "keyword"], ["STOPSIGNAL", "keyword"],
+  ["healthcheck_instruction", "keyword"], ["HEALTHCHECK", "keyword"],
+  ["shell_instruction", "keyword"], ["SHELL", "keyword"],
+  // Values
+  ["image_name", "type"], ["image_tag", "constant"],
+  ["path", "string"], ["unquoted_string", "string"],
+  // Variables
+  ["expansion", "variable_builtin"], ["variable", "variable_builtin"],
 ]);
 
 function nodeTypeToCategory(nodeType: string): string {

--- a/tests/renderer/languages.test.ts
+++ b/tests/renderer/languages.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for language detection utility.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  detectLanguage,
+  getGrammarName,
+  isLanguageSupported,
+} from "../../src/renderer/languages.ts";
+
+describe("detectLanguage", () => {
+  describe("TypeScript / JavaScript", () => {
+    it("should detect .ts as typescript", () => {
+      expect(detectLanguage("main.ts")).toBe("typescript");
+      expect(detectLanguage("src/lib.ts")).toBe("typescript");
+    });
+
+    it("should detect .tsx as tsx", () => {
+      expect(detectLanguage("App.tsx")).toBe("tsx");
+    });
+
+    it("should detect .js as javascript", () => {
+      expect(detectLanguage("index.js")).toBe("javascript");
+    });
+
+    it("should detect .jsx as jsx", () => {
+      expect(detectLanguage("Component.jsx")).toBe("jsx");
+    });
+
+    it("should detect module extensions", () => {
+      expect(detectLanguage("module.mts")).toBe("typescript");
+      expect(detectLanguage("module.cts")).toBe("typescript");
+      expect(detectLanguage("module.mjs")).toBe("javascript");
+      expect(detectLanguage("module.cjs")).toBe("javascript");
+    });
+  });
+
+  describe("Systems languages", () => {
+    it("should detect .rs as rust", () => {
+      expect(detectLanguage("main.rs")).toBe("rust");
+      expect(detectLanguage("src/lib.rs")).toBe("rust");
+    });
+
+    it("should detect .go as go", () => {
+      expect(detectLanguage("main.go")).toBe("go");
+    });
+
+    it("should detect C/C++ extensions", () => {
+      expect(detectLanguage("main.c")).toBe("c");
+      expect(detectLanguage("header.h")).toBe("c");
+      expect(detectLanguage("main.cpp")).toBe("cpp");
+      expect(detectLanguage("main.cc")).toBe("cpp");
+      expect(detectLanguage("main.cxx")).toBe("cpp");
+      expect(detectLanguage("header.hpp")).toBe("cpp");
+    });
+
+    it("should detect .zig as zig", () => {
+      expect(detectLanguage("main.zig")).toBe("zig");
+    });
+  });
+
+  describe("Scripting languages", () => {
+    it("should detect .py as python", () => {
+      expect(detectLanguage("script.py")).toBe("python");
+      expect(detectLanguage("types.pyi")).toBe("python");
+    });
+
+    it("should detect .rb as ruby", () => {
+      expect(detectLanguage("app.rb")).toBe("ruby");
+      expect(detectLanguage("Gemfile.rake")).toBe("ruby");
+    });
+
+    it("should detect .lua as lua", () => {
+      expect(detectLanguage("init.lua")).toBe("lua");
+    });
+  });
+
+  describe("Web languages", () => {
+    it("should detect .html as html", () => {
+      expect(detectLanguage("index.html")).toBe("html");
+      expect(detectLanguage("page.htm")).toBe("html");
+    });
+
+    it("should detect .css as css", () => {
+      expect(detectLanguage("styles.css")).toBe("css");
+      expect(detectLanguage("styles.scss")).toBe("css");
+    });
+  });
+
+  describe("Data formats", () => {
+    it("should detect .json as json", () => {
+      expect(detectLanguage("package.json")).toBe("json");
+      expect(detectLanguage("tsconfig.jsonc")).toBe("json");
+    });
+
+    it("should detect .yaml/.yml as yaml", () => {
+      expect(detectLanguage("config.yaml")).toBe("yaml");
+      expect(detectLanguage("docker-compose.yml")).toBe("yaml");
+    });
+
+    it("should detect .toml as toml", () => {
+      expect(detectLanguage("Cargo.toml")).toBe("toml");
+    });
+  });
+
+  describe("Shell scripts", () => {
+    it("should detect shell extensions", () => {
+      expect(detectLanguage("script.sh")).toBe("bash");
+      expect(detectLanguage("script.bash")).toBe("bash");
+      expect(detectLanguage("script.zsh")).toBe("bash");
+    });
+  });
+
+  describe("Documentation", () => {
+    it("should detect .md as markdown", () => {
+      expect(detectLanguage("README.md")).toBe("markdown");
+      expect(detectLanguage("docs/guide.mdx")).toBe("markdown");
+    });
+  });
+
+  describe("JVM languages", () => {
+    it("should detect .java as java", () => {
+      expect(detectLanguage("Main.java")).toBe("java");
+    });
+
+    it("should detect .kt as kotlin", () => {
+      expect(detectLanguage("Main.kt")).toBe("kotlin");
+      expect(detectLanguage("build.gradle.kts")).toBe("kotlin");
+    });
+  });
+
+  describe("Apple languages", () => {
+    it("should detect .swift as swift", () => {
+      expect(detectLanguage("App.swift")).toBe("swift");
+    });
+  });
+
+  describe("Database", () => {
+    it("should detect .sql as sql", () => {
+      expect(detectLanguage("migration.sql")).toBe("sql");
+    });
+  });
+
+  describe("Special filenames", () => {
+    it("should detect Dockerfile", () => {
+      expect(detectLanguage("Dockerfile")).toBe("dockerfile");
+      expect(detectLanguage("path/to/Dockerfile")).toBe("dockerfile");
+    });
+
+    it("should detect shell config files", () => {
+      expect(detectLanguage(".bashrc")).toBe("bash");
+      expect(detectLanguage(".zshrc")).toBe("bash");
+      expect(detectLanguage(".profile")).toBe("bash");
+    });
+
+    it("should detect Ruby special files", () => {
+      expect(detectLanguage("Gemfile")).toBe("ruby");
+      expect(detectLanguage("Rakefile")).toBe("ruby");
+    });
+
+    it("should be case-insensitive for special filenames", () => {
+      expect(detectLanguage("dockerfile")).toBe("dockerfile");
+      expect(detectLanguage("DOCKERFILE")).toBe("dockerfile");
+    });
+  });
+
+  describe("Fallback", () => {
+    it("should return plaintext for unknown extensions", () => {
+      expect(detectLanguage("file.xyz")).toBe("plaintext");
+      expect(detectLanguage("noextension")).toBe("plaintext");
+    });
+
+    it("should return plaintext for .gitignore", () => {
+      expect(detectLanguage(".gitignore")).toBe("plaintext");
+    });
+  });
+
+  describe("Path handling", () => {
+    it("should extract filename from full path", () => {
+      expect(detectLanguage("src/components/Button.tsx")).toBe("tsx");
+      expect(detectLanguage("/home/user/project/main.rs")).toBe("rust");
+    });
+
+    it("should handle paths with dots in directory names", () => {
+      expect(detectLanguage("node_modules/@types/react/index.d.ts")).toBe("typescript");
+    });
+  });
+});
+
+describe("isLanguageSupported", () => {
+  it("should return true for supported languages", () => {
+    expect(isLanguageSupported("typescript")).toBe(true);
+    expect(isLanguageSupported("rust")).toBe(true);
+    expect(isLanguageSupported("python")).toBe(true);
+  });
+
+  it("should return false for plaintext", () => {
+    expect(isLanguageSupported("plaintext")).toBe(false);
+  });
+});
+
+describe("getGrammarName", () => {
+  it("should return the language id for most languages", () => {
+    expect(getGrammarName("rust")).toBe("rust");
+    expect(getGrammarName("python")).toBe("python");
+    expect(getGrammarName("go")).toBe("go");
+  });
+
+  it("should return typescript for tsx", () => {
+    expect(getGrammarName("typescript")).toBe("typescript");
+    expect(getGrammarName("tsx")).toBe("typescript");
+  });
+
+  it("should return javascript for jsx", () => {
+    expect(getGrammarName("javascript")).toBe("javascript");
+    expect(getGrammarName("jsx")).toBe("javascript");
+  });
+
+  it("should return null for plaintext", () => {
+    expect(getGrammarName("plaintext")).toBe(null);
+  });
+});

--- a/tests/renderer/multi-language-highlighter.test.ts
+++ b/tests/renderer/multi-language-highlighter.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for MultiLanguageHighlighter - multi-language syntax highlighting
+ * with tree-sitter.
+ */
+
+import { beforeAll, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { MultiLanguageHighlighter } from "../../src/renderer/highlighter.ts";
+
+const WASM_DIR = path.join(import.meta.dir, "../../playground/wasm");
+
+const TYPESCRIPT_SOURCE = `const x: number = 42;
+function greet(name: string): string {
+  return "hello " + name;
+}
+`;
+
+const YAML_SOURCE = `name: multibuffer
+version: 1.0.0
+features:
+  - syntax highlighting
+  - multi-language
+enabled: true
+count: 42
+`;
+
+const MARKDOWN_SOURCE = `# Heading
+
+Some **bold** and *italic* text.
+
+\`\`\`typescript
+const x = 1;
+\`\`\`
+`;
+
+describe("MultiLanguageHighlighter", () => {
+  let highlighter: MultiLanguageHighlighter;
+
+  beforeAll(async () => {
+    highlighter = new MultiLanguageHighlighter();
+    await highlighter.init({
+      treeSitterWasmUrl: path.join(WASM_DIR, "tree-sitter.wasm"),
+      languages: {
+        typescript: path.join(WASM_DIR, "tree-sitter-typescript.wasm"),
+        yaml: path.join(WASM_DIR, "tree-sitter-yaml.wasm"),
+        markdown: path.join(WASM_DIR, "tree-sitter-markdown.wasm"),
+      },
+    });
+  });
+
+  describe("initialization", () => {
+    it("should be ready after init", () => {
+      expect(highlighter.ready).toBe(true);
+    });
+
+    it("should have loaded configured languages", () => {
+      expect(highlighter.hasLanguage("typescript")).toBe(true);
+      expect(highlighter.hasLanguage("yaml")).toBe(true);
+      expect(highlighter.hasLanguage("markdown")).toBe(true);
+    });
+
+    it("should not have unconfigured languages", () => {
+      expect(highlighter.hasLanguage("rust")).toBe(false);
+      expect(highlighter.hasLanguage("python")).toBe(false);
+    });
+
+    it("should return loaded languages set", () => {
+      const loaded = highlighter.loadedLanguages;
+      expect(loaded.has("typescript")).toBe(true);
+      expect(loaded.has("yaml")).toBe(true);
+      expect(loaded.has("markdown")).toBe(true);
+      expect(loaded.size).toBe(3);
+    });
+  });
+
+  describe("parseBuffer with explicit language", () => {
+    it("should parse TypeScript with explicit language", () => {
+      highlighter.parseBuffer("test-ts", TYPESCRIPT_SOURCE, undefined, "typescript");
+      const tokens = highlighter.getLineTokens("test-ts", 0);
+      expect(tokens.length).toBeGreaterThan(0);
+      // First token should be "const" keyword
+      expect(tokens[0]?.startColumn).toBe(0);
+      expect(tokens[0]?.color).toContain("var(--syntax-keyword");
+    });
+
+    it("should parse YAML with explicit language", () => {
+      highlighter.parseBuffer("test-yaml", YAML_SOURCE, undefined, "yaml");
+      const tokens = highlighter.getLineTokens("test-yaml", 0);
+      expect(tokens.length).toBeGreaterThan(0);
+    });
+
+    it("should parse Markdown with explicit language", () => {
+      highlighter.parseBuffer("test-md", MARKDOWN_SOURCE, undefined, "markdown");
+      const tokens = highlighter.getLineTokens("test-md", 0);
+      expect(tokens.length).toBeGreaterThan(0);
+      // First line is heading, should have keyword color
+      expect(tokens[0]?.color).toContain("var(--syntax-keyword");
+    });
+  });
+
+  describe("parseBufferWithPath (auto-detection)", () => {
+    it("should auto-detect TypeScript from .ts extension", () => {
+      highlighter.parseBufferWithPath("src/app.ts", TYPESCRIPT_SOURCE);
+      const tokens = highlighter.getLineTokens("src/app.ts", 0);
+      expect(tokens.length).toBeGreaterThan(0);
+      expect(tokens[0]?.color).toContain("var(--syntax-keyword");
+    });
+
+    it("should auto-detect YAML from .yaml extension", () => {
+      highlighter.parseBufferWithPath("config.yaml", YAML_SOURCE);
+      const tokens = highlighter.getLineTokens("config.yaml", 0);
+      expect(tokens.length).toBeGreaterThan(0);
+    });
+
+    it("should auto-detect YAML from .yml extension", () => {
+      highlighter.parseBufferWithPath("docker-compose.yml", YAML_SOURCE);
+      const tokens = highlighter.getLineTokens("docker-compose.yml", 0);
+      expect(tokens.length).toBeGreaterThan(0);
+    });
+
+    it("should auto-detect Markdown from .md extension", () => {
+      highlighter.parseBufferWithPath("README.md", MARKDOWN_SOURCE);
+      const tokens = highlighter.getLineTokens("README.md", 0);
+      expect(tokens.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("buffer language association", () => {
+    it("should remember language for subsequent parses", () => {
+      highlighter.parseBuffer("remember-test", TYPESCRIPT_SOURCE, undefined, "typescript");
+      expect(highlighter.getBufferLanguage("remember-test")).toBe("typescript");
+
+      // Re-parse without specifying language - should use stored language
+      highlighter.parseBuffer("remember-test", TYPESCRIPT_SOURCE);
+      const tokens = highlighter.getLineTokens("remember-test", 0);
+      expect(tokens.length).toBeGreaterThan(0);
+      expect(tokens[0]?.color).toContain("var(--syntax-keyword");
+    });
+
+    it("should allow changing buffer language", () => {
+      highlighter.parseBuffer("change-lang", TYPESCRIPT_SOURCE, undefined, "typescript");
+      expect(highlighter.getBufferLanguage("change-lang")).toBe("typescript");
+
+      // Change to YAML (even though it's TypeScript code - just testing language switch)
+      highlighter.setBufferLanguage("change-lang", "yaml");
+      expect(highlighter.getBufferLanguage("change-lang")).toBe("yaml");
+    });
+  });
+
+  describe("unsupported language handling", () => {
+    it("should return empty tokens for unsupported language", () => {
+      highlighter.parseBuffer("rust-file", "fn main() {}", undefined, "rust");
+      const tokens = highlighter.getLineTokens("rust-file", 0);
+      expect(tokens).toEqual([]);
+    });
+
+    it("should return empty tokens for plaintext", () => {
+      highlighter.parseBuffer("plaintext-file", "hello world", undefined, "plaintext");
+      const tokens = highlighter.getLineTokens("plaintext-file", 0);
+      expect(tokens).toEqual([]);
+    });
+  });
+
+  describe("removeBuffer", () => {
+    it("should remove buffer tree and language association", () => {
+      highlighter.parseBuffer("to-remove", TYPESCRIPT_SOURCE, undefined, "typescript");
+      expect(highlighter.getBufferLanguage("to-remove")).toBe("typescript");
+      expect(highlighter.getLineTokens("to-remove", 0).length).toBeGreaterThan(0);
+
+      highlighter.removeBuffer("to-remove");
+      expect(highlighter.getBufferLanguage("to-remove")).toBeUndefined();
+      expect(highlighter.getLineTokens("to-remove", 0)).toEqual([]);
+    });
+  });
+
+  describe("multiple buffers with different languages", () => {
+    it("should highlight multiple buffers with different languages correctly", () => {
+      // Parse TypeScript
+      highlighter.parseBuffer("multi-ts", TYPESCRIPT_SOURCE, undefined, "typescript");
+      // Parse YAML
+      highlighter.parseBuffer("multi-yaml", YAML_SOURCE, undefined, "yaml");
+      // Parse Markdown
+      highlighter.parseBuffer("multi-md", MARKDOWN_SOURCE, undefined, "markdown");
+
+      // Verify each buffer has correct highlighting
+      const tsTokens = highlighter.getLineTokens("multi-ts", 0);
+      const yamlTokens = highlighter.getLineTokens("multi-yaml", 0);
+      const mdTokens = highlighter.getLineTokens("multi-md", 0);
+
+      expect(tsTokens.length).toBeGreaterThan(0);
+      expect(yamlTokens.length).toBeGreaterThan(0);
+      expect(mdTokens.length).toBeGreaterThan(0);
+
+      // TypeScript first line should have keyword ("const")
+      expect(tsTokens[0]?.color).toContain("var(--syntax-keyword");
+
+      // Markdown first line is heading, should have keyword style
+      expect(mdTokens[0]?.color).toContain("var(--syntax-keyword");
+    });
+  });
+});
+
+describe("MultiLanguageHighlighter dynamic loading", () => {
+  it("should allow loading languages after init", async () => {
+    const highlighter = new MultiLanguageHighlighter();
+    await highlighter.init({
+      treeSitterWasmUrl: path.join(WASM_DIR, "tree-sitter.wasm"),
+      languages: {
+        typescript: path.join(WASM_DIR, "tree-sitter-typescript.wasm"),
+      },
+    });
+
+    expect(highlighter.hasLanguage("yaml")).toBe(false);
+
+    // Dynamically load YAML
+    await highlighter.loadLanguage("yaml", path.join(WASM_DIR, "tree-sitter-yaml.wasm"));
+
+    expect(highlighter.hasLanguage("yaml")).toBe(true);
+
+    // Now we can parse YAML
+    highlighter.parseBuffer("dynamic-yaml", YAML_SOURCE, undefined, "yaml");
+    const tokens = highlighter.getLineTokens("dynamic-yaml", 0);
+    expect(tokens.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `MultiLanguageHighlighter` class that loads multiple tree-sitter grammars and can parse buffers with different languages
- Add `detectLanguage()` utility that maps file extensions and special filenames to language IDs
- Add `parseBufferWithPath()` method for automatic language detection from file paths
- Extend `SyntaxHighlighter` interface documentation with examples for custom implementations
- Add node type → category mappings for 15+ additional languages
- Export new types and utilities from the renderer module

## Changes

### New files
- `src/renderer/languages.ts` - Language detection and configuration utilities
- `tests/renderer/languages.test.ts` - Tests for language detection (37 tests)
- `tests/renderer/multi-language-highlighter.test.ts` - Tests for multi-language highlighter (18 tests)

### Modified files
- `src/renderer/highlighter.ts` - Add `MultiLanguageHighlighter` class and enhanced documentation
- `src/renderer/theme.ts` - Add node type mappings for: Rust, Go, Python, Ruby, HTML, CSS, JSON, TOML, Bash, C/C++, Java, Kotlin, Swift, Zig, Lua, SQL, Dockerfile
- `src/renderer/index.ts` - Export new types and utilities

## Usage

```typescript
import { MultiLanguageHighlighter, detectLanguage } from "multibuffer/renderer";

const highlighter = new MultiLanguageHighlighter();
await highlighter.init({
  treeSitterWasmUrl: "/wasm/tree-sitter.wasm",
  languages: {
    typescript: "/grammars/tree-sitter-typescript.wasm",
    rust: "/grammars/tree-sitter-rust.wasm",
    python: "/grammars/tree-sitter-python.wasm",
  },
});

// Auto-detect language from filename
highlighter.parseBufferWithPath("src/main.rs", rustCode);

// Or specify language explicitly
highlighter.parseBuffer("file.ts", tsCode, undefined, "typescript");

// Get tokens for rendering
const tokens = highlighter.getLineTokens("src/main.rs", 0);
```

## Test plan

- [x] All existing renderer tests pass (318 tests)
- [x] New language detection tests pass (37 tests)
- [x] New multi-language highlighter tests pass (18 tests)
- [x] Lint passes on all changed files
- [x] Type checking passes on changed files

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)