### PR TITLE
feat(multibuffer): add viewport-scoped anchor resolution

### DIFF
--- a/src/multibuffer/multibuffer.ts
+++ b/src/multibuffer/multibuffer.ts
@@ -340,6 +340,93 @@ class MultiBufferSnapshotImpl implements MultiBufferSnapshot {
     });
   }
 
+  resolveAnchorsInViewport(
+    anchors: readonly Anchor[],
+    startRow: MultiBufferRow,
+    endRow: MultiBufferRow,
+  ): (MultiBufferPoint | undefined)[] {
+    if (anchors.length === 0) return [];
+
+    // Early exit for empty viewport
+    if (startRow >= endRow) {
+      return anchors.map(() => undefined);
+    }
+
+    const excerptDataCache = this.excerptDataIndex;
+    const excerptInfoCache = this.excerptInfoIndex;
+    const snapshotCache = new Map<string, BufferSnapshot>();
+    const editsCache = new Map<string, readonly EditEntry[]>();
+
+    return anchors.map((anchor) => {
+      // 1. Follow replacement chain to current excerpt ID
+      let currentId = anchor.excerptId;
+      const maxChain = 100;
+      for (let i = 0; i < maxChain; i++) {
+        const key = `${currentId.index}:${currentId.generation}`;
+        const replacement = this._replacedExcerpts.get(key);
+        if (!replacement) break;
+        currentId = replacement;
+      }
+
+      // 2. Quick viewport overlap check via O(1) excerpt info lookup
+      const excerptKey = `${currentId.index}:${currentId.generation}`;
+      const info = excerptInfoCache.get(excerptKey);
+      if (!info) return undefined;
+
+      // Excerpt overlaps viewport if [info.startRow, info.endRow) intersects [startRow, endRow)
+      // i.e., info.endRow > startRow AND info.startRow < endRow
+      if (info.endRow <= startRow || info.startRow >= endRow) {
+        // Excerpt doesn't overlap viewport — skip expensive resolution
+        return undefined;
+      }
+
+      // 3. Find excerpt data for full resolution
+      const initialExcerpt = excerptDataCache.get(excerptKey);
+      if (!initialExcerpt) return undefined;
+
+      // 4. Resolve buffer point, reusing cached edit slice + snapshot
+      // biome-ignore lint/plugin/no-type-assertion: expect: BufferId is branded string, Map key is string
+      const bid = initialExcerpt.bufferId as string;
+      const buffer = this._buffers.get(bid);
+
+      let bufferPoint: BufferPoint;
+      if (!buffer) {
+        bufferPoint = initialExcerpt.buffer.offsetToPoint(anchor.textAnchor.offset);
+      } else {
+        let snap = snapshotCache.get(bid);
+        if (!snap) {
+          snap = buffer.snapshot();
+          snapshotCache.set(bid, snap);
+        }
+
+        const editsKey = `${bid}@${anchor.textAnchor.version}`;
+        let edits = editsCache.get(editsKey);
+        if (!edits) {
+          edits = buffer.editsSince(anchor.textAnchor.version);
+          editsCache.set(editsKey, edits);
+        }
+
+        const adjustedOffset = adjustOffset(
+          anchor.textAnchor.offset,
+          anchor.textAnchor.bias,
+          edits,
+        );
+        const clampedOffset = snap.clipOffset(adjustedOffset, anchor.textAnchor.bias);
+        bufferPoint = snap.offsetToPoint(clampedOffset);
+      }
+
+      // 5. Find best excerpt for this buffer point
+      const resolvedExcerpt = this._findExcerptForBufferPoint(bufferPoint, initialExcerpt);
+
+      // 6. Convert to multibuffer point
+      const resolvedKey = `${resolvedExcerpt.id.index}:${resolvedExcerpt.id.generation}`;
+      const resolvedInfo = excerptInfoCache.get(resolvedKey);
+      if (!resolvedInfo) return undefined;
+
+      return this._bufferPointToMbPoint(bufferPoint, resolvedExcerpt, resolvedInfo);
+    });
+  }
+
   private _bufferPointToMbPoint(
     bufferPoint: BufferPoint,
     excerptData: Excerpt,

--- a/src/multibuffer/types.ts
+++ b/src/multibuffer/types.ts
@@ -151,6 +151,17 @@ export interface MultiBufferSnapshot {
   lines(startRow: MultiBufferRow, endRow: MultiBufferRow): readonly string[];
   resolveAnchor(anchor: Anchor): MultiBufferPoint | undefined;
   resolveAnchors(anchors: readonly Anchor[]): (MultiBufferPoint | undefined)[];
+  /**
+   * Resolve anchors that are visible within a viewport row range.
+   * Anchors whose excerpt doesn't overlap [startRow, endRow) return undefined
+   * without doing the expensive resolution work (edit replay, offset adjustment).
+   * Returns same-length array as input to preserve index correspondence.
+   */
+  resolveAnchorsInViewport(
+    anchors: readonly Anchor[],
+    startRow: MultiBufferRow,
+    endRow: MultiBufferRow,
+  ): (MultiBufferPoint | undefined)[];
   clipPoint(point: MultiBufferPoint, bias: import("../buffer/types.ts").Bias): MultiBufferPoint;
   excerptBoundaries(
     startRow: MultiBufferRow,

--- a/tests/multibuffer/anchor.test.ts
+++ b/tests/multibuffer/anchor.test.ts
@@ -28,7 +28,9 @@ import {
   excerptRange,
   expectOffset,
   expectPoint,
+  generateText,
   mbPoint,
+  mbRow,
   offset,
   resetCounters,
 } from "../helpers.ts";
@@ -860,5 +862,282 @@ describe("Batch Anchor Resolution", () => {
     const batchResults = snap.resolveAnchors([a1, a2]);
     expect(batchResults[0]).toEqual(snap.resolveAnchor(a1));
     expect(batchResults[1]).toEqual(snap.resolveAnchor(a2));
+  });
+});
+
+
+describe("Viewport-Scoped Anchor Resolution", () => {
+  test("resolveAnchorsInViewport returns undefined for anchors outside viewport", () => {
+    // Create multibuffer with 3 excerpts: rows 0-5, 5-10, 10-15
+    const buf1 = createBuffer(createBufferId(), generateText(5));
+    const buf2 = createBuffer(createBufferId(), generateText(5));
+    const buf3 = createBuffer(createBufferId(), generateText(5));
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf1, excerptRange(0, 5)); // rows 0-5
+    mb.addExcerpt(buf2, excerptRange(0, 5)); // rows 5-10
+    mb.addExcerpt(buf3, excerptRange(0, 5)); // rows 10-15
+
+    // Create anchors in each excerpt
+    const a1 = mb.createAnchor(mbPoint(2, 0), Bias.Right);  // excerpt 1 (rows 0-5)
+    const a2 = mb.createAnchor(mbPoint(7, 0), Bias.Right);  // excerpt 2 (rows 5-10)
+    const a3 = mb.createAnchor(mbPoint(12, 0), Bias.Right); // excerpt 3 (rows 10-15)
+
+    expect(a1).toBeDefined();
+    expect(a2).toBeDefined();
+    expect(a3).toBeDefined();
+    if (!a1 || !a2 || !a3) return;
+
+    const snap = mb.snapshot();
+    // Viewport covers only rows 5-10 (excerpt 2)
+    const results = snap.resolveAnchorsInViewport([a1, a2, a3], mbRow(5), mbRow(10));
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toBeUndefined(); // a1 outside viewport
+    expect(results[1]).toBeDefined();   // a2 inside viewport
+    expect(results[2]).toBeUndefined(); // a3 outside viewport
+
+    // Verify the visible anchor matches full resolution
+    if (results[1]) {
+      expectPoint(results[1], 7, 0);
+    }
+  });
+
+  test("resolveAnchorsInViewport resolves all anchors when viewport covers all excerpts", () => {
+    const buf = createBuffer(createBufferId(), generateText(10));
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 10));
+
+    const anchors: Anchor[] = [];
+    for (let row = 0; row < 10; row++) {
+      const a = mb.createAnchor(mbPoint(row, 0), Bias.Right);
+      if (a) anchors.push(a);
+    }
+    expect(anchors).toHaveLength(10);
+
+    const snap = mb.snapshot();
+    // Viewport covers all rows
+    const viewportResults = snap.resolveAnchorsInViewport(anchors, mbRow(0), mbRow(10));
+    const fullResults = snap.resolveAnchors(anchors);
+
+    expect(viewportResults).toHaveLength(fullResults.length);
+    for (let i = 0; i < anchors.length; i++) {
+      expect(viewportResults[i]).toEqual(fullResults[i]);
+    }
+  });
+
+  test("resolveAnchorsInViewport handles empty anchor list", () => {
+    const buf = createBuffer(createBufferId(), "Hello");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 1));
+
+    const result = mb.snapshot().resolveAnchorsInViewport([], mbRow(0), mbRow(1));
+    expect(result).toEqual([]);
+  });
+
+  test("resolveAnchorsInViewport handles empty viewport range", () => {
+    const buf = createBuffer(createBufferId(), generateText(5));
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 5));
+
+    const a = mb.createAnchor(mbPoint(2, 0), Bias.Right);
+    expect(a).toBeDefined();
+    if (!a) return;
+
+    const snap = mb.snapshot();
+    // Empty viewport (startRow === endRow)
+    const results = snap.resolveAnchorsInViewport([a], mbRow(0), mbRow(0));
+    expect(results).toHaveLength(1);
+    expect(results[0]).toBeUndefined();
+  });
+
+  test("resolveAnchorsInViewport includes excerpt partially overlapping viewport start", () => {
+    const buf1 = createBuffer(createBufferId(), generateText(5));
+    const buf2 = createBuffer(createBufferId(), generateText(5));
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf1, excerptRange(0, 5)); // rows 0-5
+    mb.addExcerpt(buf2, excerptRange(0, 5)); // rows 5-10
+
+    const a1 = mb.createAnchor(mbPoint(3, 0), Bias.Right); // excerpt 1, row 3
+    const a2 = mb.createAnchor(mbPoint(7, 0), Bias.Right); // excerpt 2, row 7
+    expect(a1).toBeDefined();
+    expect(a2).toBeDefined();
+    if (!a1 || !a2) return;
+
+    const snap = mb.snapshot();
+    // Viewport starts mid-way through excerpt 1 (row 3-8)
+    // Excerpt 1 (rows 0-5) overlaps viewport [3, 8) because 5 > 3 and 0 < 8
+    // Excerpt 2 (rows 5-10) overlaps viewport [3, 8) because 10 > 3 and 5 < 8
+    const results = snap.resolveAnchorsInViewport([a1, a2], mbRow(3), mbRow(8));
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toBeDefined(); // excerpt 1 overlaps viewport
+    expect(results[1]).toBeDefined(); // excerpt 2 overlaps viewport
+  });
+
+  test("resolveAnchorsInViewport includes excerpt partially overlapping viewport end", () => {
+    const buf1 = createBuffer(createBufferId(), generateText(5));
+    const buf2 = createBuffer(createBufferId(), generateText(5));
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf1, excerptRange(0, 5)); // rows 0-5
+    mb.addExcerpt(buf2, excerptRange(0, 5)); // rows 5-10
+
+    const a1 = mb.createAnchor(mbPoint(2, 0), Bias.Right); // excerpt 1, row 2
+    const a2 = mb.createAnchor(mbPoint(8, 0), Bias.Right); // excerpt 2, row 8
+    expect(a1).toBeDefined();
+    expect(a2).toBeDefined();
+    if (!a1 || !a2) return;
+
+    const snap = mb.snapshot();
+    // Viewport ends mid-way through excerpt 2 (row 2-7)
+    // Excerpt 1 overlaps because 5 > 2 and 0 < 7
+    // Excerpt 2 overlaps because 10 > 2 and 5 < 7
+    const results = snap.resolveAnchorsInViewport([a1, a2], mbRow(2), mbRow(7));
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toBeDefined(); // excerpt 1 overlaps viewport
+    expect(results[1]).toBeDefined(); // excerpt 2 overlaps viewport
+  });
+
+  test("resolveAnchorsInViewport follows replaced_excerpts chain for viewport check", () => {
+    const buf = createBuffer(createBufferId(), generateText(10));
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 5)); // rows 0-5
+
+    // Create anchor in first excerpt
+    const a = mb.createAnchor(mbPoint(2, 0), Bias.Right);
+    expect(a).toBeDefined();
+    if (!a) return;
+
+    // Replace excerpts — anchor should follow replacement chain
+    mb.setExcerptsForBuffer(buf, [excerptRange(0, 5)]); // new excerpt at same position
+
+    const snap = mb.snapshot();
+    // Viewport covers the new excerpt
+    const results = snap.resolveAnchorsInViewport([a], mbRow(0), mbRow(5));
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toBeDefined();
+    if (results[0]) {
+      expectPoint(results[0], 2, 0);
+    }
+  });
+
+  test("resolveAnchorsInViewport returns undefined for stale anchors even in viewport", () => {
+    const buf = createBuffer(createBufferId(), generateText(5));
+    const mb = createMultiBuffer();
+    const eid = mb.addExcerpt(buf, excerptRange(0, 5));
+
+    const a = mb.createAnchor(mbPoint(2, 0), Bias.Right);
+    expect(a).toBeDefined();
+    if (!a) return;
+
+    // Remove excerpt — anchor becomes stale
+    mb.removeExcerpt(eid);
+
+    const snap = mb.snapshot();
+    const results = snap.resolveAnchorsInViewport([a], mbRow(0), mbRow(5));
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toBeUndefined();
+  });
+
+  test("resolveAnchorsInViewport with mixed visible and non-visible anchors from multiple buffers", () => {
+    const buf1 = createBuffer(createBufferId(), generateText(5));
+    const buf2 = createBuffer(createBufferId(), generateText(5));
+    const buf3 = createBuffer(createBufferId(), generateText(5));
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf1, excerptRange(0, 5)); // rows 0-5
+    mb.addExcerpt(buf2, excerptRange(0, 5)); // rows 5-10
+    mb.addExcerpt(buf3, excerptRange(0, 5)); // rows 10-15
+
+    // Create multiple anchors per excerpt
+    const anchors: Anchor[] = [];
+    for (let row = 0; row < 15; row += 2) {
+      const a = mb.createAnchor(mbPoint(row, 0), Bias.Right);
+      if (a) anchors.push(a);
+    }
+    expect(anchors.length).toBeGreaterThan(0);
+
+    const snap = mb.snapshot();
+    // Viewport covers only middle excerpt (rows 5-10)
+    const viewportResults = snap.resolveAnchorsInViewport(anchors, mbRow(5), mbRow(10));
+    const fullResults = snap.resolveAnchors(anchors);
+
+    expect(viewportResults).toHaveLength(anchors.length);
+
+    // Verify: only anchors in the middle excerpt should be resolved
+    for (let i = 0; i < anchors.length; i++) {
+      const anchor = anchors[i];
+      if (!anchor) continue;
+
+      // Get the excerpt info to check if it's in viewport
+      const excerptKey = `${anchor.excerptId.index}:${anchor.excerptId.generation}`;
+      const info = snap.excerpts.find(
+        (e) => `${e.id.index}:${e.id.generation}` === excerptKey
+      );
+
+      if (info && info.endRow > 5 && info.startRow < 10) {
+        // Excerpt overlaps viewport — should match full resolution
+        expect(viewportResults[i]).toEqual(fullResults[i]);
+      } else {
+        // Excerpt doesn't overlap viewport — should be undefined
+        expect(viewportResults[i]).toBeUndefined();
+      }
+    }
+  });
+
+  test("resolveAnchorsInViewport preserves index correspondence", () => {
+    const buf = createBuffer(createBufferId(), generateText(15));
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 5));  // rows 0-5
+    mb.addExcerpt(buf, excerptRange(5, 10)); // rows 5-10
+    mb.addExcerpt(buf, excerptRange(10, 15)); // rows 10-15
+
+    const a0 = mb.createAnchor(mbPoint(2, 3), Bias.Right);  // visible
+    const a1 = mb.createAnchor(mbPoint(7, 4), Bias.Right);  // visible
+    const a2 = mb.createAnchor(mbPoint(12, 5), Bias.Right); // not visible
+
+    expect(a0).toBeDefined();
+    expect(a1).toBeDefined();
+    expect(a2).toBeDefined();
+    if (!a0 || !a1 || !a2) return;
+
+    const snap = mb.snapshot();
+    // Viewport covers first two excerpts
+    const results = snap.resolveAnchorsInViewport([a0, a1, a2], mbRow(0), mbRow(10));
+
+    // Check index correspondence is maintained
+    expect(results[0]).toBeDefined();
+    expect(results[1]).toBeDefined();
+    expect(results[2]).toBeUndefined();
+
+    if (results[0]) expectPoint(results[0], 2, 3);
+    if (results[1]) expectPoint(results[1], 7, 4);
+  });
+
+  test("resolveAnchorsInViewport applies edit replay for visible anchors", () => {
+    const buf = createBuffer(createBufferId(), "ABCDE\nFGHIJ\nKLMNO");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 3));
+
+    // Create anchor at row 1, column 2
+    const a = mb.createAnchor(mbPoint(1, 2), Bias.Right);
+    expect(a).toBeDefined();
+    if (!a) return;
+
+    // Insert text before the anchor position
+    buf.insert(offset(6), "XX"); // Insert at start of row 1
+
+    const snap = mb.snapshot();
+    // Viewport covers all rows
+    const viewportResults = snap.resolveAnchorsInViewport([a], mbRow(0), mbRow(3));
+    const fullResults = snap.resolveAnchors([a]);
+
+    // Both should give same result with edit replay applied
+    expect(viewportResults[0]).toEqual(fullResults[0]);
+    if (viewportResults[0]) {
+      // Original was row 1, col 2. After "XX" insert, should be row 1, col 4
+      expectPoint(viewportResults[0], 1, 4);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds `resolveAnchorsInViewport()` method to `MultiBufferSnapshot` interface
- Optimizes anchor resolution by skipping expensive work for anchors outside a viewport row range
- For anchors whose excerpt doesn't overlap `[startRow, endRow)`, returns `undefined` without performing edit replay or offset adjustment
- Maintains same-length array return to preserve index correspondence with input anchors

## Implementation Details

- O(1) viewport overlap check via `excerptInfoIndex` before full resolution
- Follows replacement chain before viewport check for moved anchors
- Reuses buffer snapshot and edit caches from `resolveAnchors` pattern

## Performance Benefit

For large anchor sets (e.g., 1000+ diagnostic markers), filtering to ~20 visible anchors before doing edit replay provides meaningful performance wins.

## Test plan

- [x] Added 11 tests for viewport-scoped anchor resolution covering:
  - Anchors inside/outside viewport
  - Empty viewport range
  - Partial excerpt overlap at viewport boundaries
  - Replaced excerpt chain following
  - Stale anchor handling
  - Mixed visible/non-visible anchors from multiple buffers
  - Edit replay verification for visible anchors
- [x] All existing tests pass (1225 tests, 0 failures)
- [x] Lint passes (Biome)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)