### PR TITLE
fix(e2e): update selectors to match actual renderer DOM structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   },
   "type": "module",
   "scripts": {
-    "test": "bun test",
-    "test:watch": "bun test --watch",
+    "test": "bun test tests/buffer tests/diff tests/editor tests/fuzz tests/multibuffer tests/project tests/react tests/renderer tests/worker",
+    "test:watch": "bun test --watch tests/buffer tests/diff tests/editor tests/fuzz tests/multibuffer tests/project tests/react tests/renderer tests/worker",
     "test:e2e": "bunx playwright test",
     "fuzz": "bun test tests/fuzz/",
     "bench": "bun run benchmarks/index.ts",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   },
   "type": "module",
   "scripts": {
-    "test": "bun test tests/buffer tests/diff tests/editor tests/fuzz tests/multibuffer tests/project tests/react tests/renderer tests/worker",
-    "test:watch": "bun test --watch tests/buffer tests/diff tests/editor tests/fuzz tests/multibuffer tests/project tests/react tests/renderer tests/worker",
+    "test": "bun test",
+    "test:watch": "bun test --watch",
     "test:e2e": "bunx playwright test",
     "fuzz": "bun test tests/fuzz/",
     "bench": "bun run benchmarks/index.ts",

--- a/src/renderer/dom.ts
+++ b/src/renderer/dom.ts
@@ -314,7 +314,6 @@ export class DomRenderer implements Renderer {
     // Cursor element
     const cursorEl = document.createElement("div");
     cursorEl.setAttribute("data-cursor", "");
-    cursorEl.setAttribute("data-testid", "cursor");
     cursorEl.style.cssText = `position:absolute;width:2px;background:var(--editor-cursor, #ebdbb2);display:none;height:${this._measurements.lineHeight}px;z-index:10;`;
     this._cursorEl = cursorEl;
 

--- a/src/renderer/dom.ts
+++ b/src/renderer/dom.ts
@@ -314,6 +314,7 @@ export class DomRenderer implements Renderer {
     // Cursor element
     const cursorEl = document.createElement("div");
     cursorEl.setAttribute("data-cursor", "");
+    cursorEl.setAttribute("data-testid", "cursor");
     cursorEl.style.cssText = `position:absolute;width:2px;background:var(--editor-cursor, #ebdbb2);display:none;height:${this._measurements.lineHeight}px;z-index:10;`;
     this._cursorEl = cursorEl;
 
@@ -1005,6 +1006,7 @@ export class DomRenderer implements Renderer {
 
     while (this._rowPool.length < count) {
       const root = document.createElement("div");
+      root.setAttribute("data-row", "");
       root.style.cssText =
         `display:none;height:${lh}px;line-height:${lh}px;white-space:pre;`;
 

--- a/tests/e2e/editor.e2e.ts
+++ b/tests/e2e/editor.e2e.ts
@@ -25,12 +25,13 @@ test.describe("Editor basics", () => {
   });
 
   test("lines render in the viewport", async ({ page }) => {
-    // Lines are rendered as div[data-row] elements inside the scroll container
-    const rows = page.locator("#editor [data-row]");
-    await expect(rows.first()).toBeVisible();
+    // Lines are rendered as div[data-row] elements inside the scroll container.
+    // Filter to visible rows only — the pool keeps hidden rows in the DOM.
+    const visibleRows = page.locator("#editor [data-row]").filter({ visible: true });
+    await expect(visibleRows.first()).toBeVisible();
 
-    // Should have multiple rows rendered
-    const count = await rows.count();
+    // Should have multiple visible rows rendered
+    const count = await visibleRows.count();
     expect(count).toBeGreaterThan(0);
   });
 

--- a/tests/e2e/editor.e2e.ts
+++ b/tests/e2e/editor.e2e.ts
@@ -5,6 +5,11 @@ import { expect, test } from "@playwright/test";
  *
  * These tests verify the full pipeline:
  * Editor → MultiBuffer → DomRenderer → DOM
+ *
+ * The renderer uses data-attributes (not CSS classes) for DOM elements:
+ * - [data-row] for line/header rows
+ * - [data-cursor] for the cursor element
+ * - textarea for the hidden input handler
  */
 
 test.describe("Editor basics", () => {
@@ -20,12 +25,12 @@ test.describe("Editor basics", () => {
   });
 
   test("lines render in the viewport", async ({ page }) => {
-    // Lines are rendered as .line elements inside the scroll container
-    const lines = page.locator("#editor .line");
-    await expect(lines.first()).toBeVisible();
+    // Lines are rendered as div[data-row] elements inside the scroll container
+    const rows = page.locator("#editor [data-row]");
+    await expect(rows.first()).toBeVisible();
 
-    // Should have multiple lines (sources are loaded by default)
-    const count = await lines.count();
+    // Should have multiple rows rendered
+    const count = await rows.count();
     expect(count).toBeGreaterThan(0);
   });
 
@@ -36,11 +41,11 @@ test.describe("Editor basics", () => {
     expect(box).not.toBeNull();
     if (!box) return;
 
-    // Click at a position within the editor (below gutter area)
+    // Click at a position within the editor
     await page.mouse.click(box.x + 100, box.y + 50);
 
     // The cursor element should exist and be visible
-    const cursor = page.locator("#editor .cursor");
+    const cursor = page.locator("#editor [data-cursor]");
     await expect(cursor).toBeVisible();
   });
 
@@ -53,14 +58,14 @@ test.describe("Editor basics", () => {
     const testText = "hello e2e";
     await page.keyboard.type(testText);
 
-    // Verify the text appears in the rendered lines
-    const lineWithText = page.locator("#editor .line", { hasText: testText });
-    await expect(lineWithText).toBeVisible();
+    // Verify the text appears in the rendered rows
+    const rowWithText = page.locator("#editor [data-row]", { hasText: testText });
+    await expect(rowWithText).toBeVisible();
   });
 
   test("scenario picker switches content", async ({ page }) => {
-    // Find the scenario picker panel
-    const picker = page.locator("text=Fixture").locator("..");
+    // Find the scenario picker panel (heading says "Demos")
+    const picker = page.locator("text=Demos").locator("..");
     await expect(picker).toBeVisible();
 
     // Click on "Unicode" scenario
@@ -70,7 +75,7 @@ test.describe("Editor basics", () => {
     // Wait for Unicode-specific content to appear in the editor.
     // The Unicode fixture contains CJK text like "你好世界" that won't
     // be present in the default "All files" scenario.
-    const unicodeLine = page.locator("#editor .line", { hasText: "你好世界" });
+    const unicodeLine = page.locator("#editor [data-row]", { hasText: "你好世界" });
     await expect(unicodeLine).toBeVisible({ timeout: 5_000 });
   });
 });
@@ -85,7 +90,7 @@ test.describe("Editor keyboard navigation", () => {
 
   test("arrow keys move cursor", async ({ page }) => {
     // Get initial cursor position
-    const cursor = page.locator("#editor .cursor");
+    const cursor = page.locator("#editor [data-cursor]");
     await expect(cursor).toBeVisible();
     const initialBox = await cursor.boundingBox();
     expect(initialBox).not.toBeNull();
@@ -97,7 +102,7 @@ test.describe("Editor keyboard navigation", () => {
     const initialY = initialBox.y;
     await page.waitForFunction(
       (prevY) => {
-        const el = document.querySelector("#editor .cursor");
+        const el = document.querySelector("#editor [data-cursor]");
         if (!el) return false;
         const rect = el.getBoundingClientRect();
         return rect.y > prevY;
@@ -118,14 +123,14 @@ test.describe("Editor keyboard navigation", () => {
     await page.keyboard.type("abc");
 
     // Verify text appears
-    const lineWithAbc = page.locator("#editor .line", { hasText: "abc" });
-    await expect(lineWithAbc).toBeVisible();
+    const rowWithAbc = page.locator("#editor [data-row]", { hasText: "abc" });
+    await expect(rowWithAbc).toBeVisible();
 
     // Press backspace to delete 'c'
     await page.keyboard.press("Backspace");
 
     // Text should now be "ab"
-    const lineWithAb = page.locator("#editor .line", { hasText: /ab[^c]|ab$/ });
-    await expect(lineWithAb).toBeVisible();
+    const rowWithAb = page.locator("#editor [data-row]", { hasText: /ab[^c]|ab$/ });
+    await expect(rowWithAb).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- E2e tests assumed CSS classes (`.line`, `.cursor`) that the renderer never used — it uses inline styles with no class attributes
- Add `data-row` and `data-testid="cursor"` attributes to renderer for testability
- Update all e2e selectors to use data attributes instead of CSS classes
- Fix scenario picker test to match actual heading text ("Demos" not "Fixture")

## Test plan
- [x] `bun run test` — 2265 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] E2e tests — needs CI to verify (requires Playwright + built playground)