### PR TITLE
feat(multibuffer): add FileNavigator for file-to-excerpt bridge

### DIFF
--- a/src/multibuffer/file-navigator.ts
+++ b/src/multibuffer/file-navigator.ts
@@ -1,0 +1,154 @@
+/**
+ * FileNavigator: bridges file selection and excerpt management.
+ *
+ * Maps file paths to excerpts in a MultiBuffer, creating them on demand
+ * via an async `readFile` callback. Stays in sync with external excerpt
+ * removal by listening to `excerptRemoved` events.
+ */
+
+import { createBuffer } from "../buffer/buffer.ts";
+import type {
+  BufferId,
+  BufferRow,
+  ExcerptId,
+  ExcerptRange,
+  MultiBuffer,
+} from "./types.ts";
+
+/** Info about an opened file tracked by the navigator. */
+export interface OpenedFileInfo {
+  readonly filePath: string;
+  readonly excerptId: ExcerptId;
+  readonly bufferId: BufferId;
+}
+
+/** Options for creating a FileNavigator. */
+export interface FileNavigatorOptions {
+  /** Async function to read file contents. Platform-agnostic. */
+  readonly readFile: (path: string) => Promise<string>;
+}
+
+/** A file-to-excerpt navigation bridge over a MultiBuffer. */
+export interface FileNavigator {
+  /**
+   * Open a file in the multibuffer. Creates a full-file excerpt if the file
+   * is not already open; returns the existing excerpt ID otherwise.
+   */
+  openFile(filePath: string): Promise<ExcerptId>;
+
+  /** Check if a file is currently shown as an excerpt. */
+  hasFile(filePath: string): boolean;
+
+  /** Get info for an opened file, or null if not open. */
+  getExcerptForFile(filePath: string): OpenedFileInfo | null;
+
+  /** Close/remove a file's excerpt. No-op if not open. */
+  closeFile(filePath: string): void;
+
+  /** Read-only view of all currently opened files. */
+  readonly files: ReadonlyMap<string, OpenedFileInfo>;
+
+  /** Clean up event listeners and internal state. */
+  destroy(): void;
+}
+
+let nextId = 1;
+function generateBufferId(): BufferId {
+  // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction for internal buffer IDs
+  return `file-nav-${nextId++}` as BufferId;
+}
+
+/**
+ * Create a FileNavigator that bridges file paths to excerpts in a MultiBuffer.
+ *
+ * The navigator tracks which files are open, creates buffers + excerpts on
+ * demand, and stays in sync when excerpts are removed externally.
+ */
+export function createFileNavigator(
+  multiBuffer: MultiBuffer,
+  options: FileNavigatorOptions,
+): FileNavigator {
+  const { readFile } = options;
+  const fileMap = new Map<string, OpenedFileInfo>();
+  // Reverse index: excerpt key → file path (for excerptRemoved sync)
+  const excerptToFile = new Map<string, string>();
+
+  function excerptKey(id: ExcerptId): string {
+    return `${id.index}:${id.generation}`;
+  }
+
+  const onExcerptRemoved = (id: ExcerptId) => {
+    const key = excerptKey(id);
+    const filePath = excerptToFile.get(key);
+    if (filePath !== undefined) {
+      excerptToFile.delete(key);
+      fileMap.delete(filePath);
+    }
+  };
+
+  multiBuffer.on("excerptRemoved", onExcerptRemoved);
+
+  return {
+    async openFile(filePath: string): Promise<ExcerptId> {
+      const existing = fileMap.get(filePath);
+      if (existing) {
+        return existing.excerptId;
+      }
+
+      const text = await readFile(filePath);
+      const bufferId = generateBufferId();
+      const buffer = createBuffer(bufferId, text);
+      const lineCount = buffer.snapshot().lineCount;
+
+      const range: ExcerptRange = {
+        context: {
+          // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction
+          start: { row: 0 as BufferRow, column: 0 },
+          // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction
+          end: { row: lineCount as BufferRow, column: 0 },
+        },
+        primary: {
+          // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction
+          start: { row: 0 as BufferRow, column: 0 },
+          // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction
+          end: { row: lineCount as BufferRow, column: 0 },
+        },
+      };
+
+      const excerptId = multiBuffer.addExcerpt(buffer, range, {
+        metadata: { filePath },
+      });
+
+      const info: OpenedFileInfo = { filePath, excerptId, bufferId };
+      fileMap.set(filePath, info);
+      excerptToFile.set(excerptKey(excerptId), filePath);
+
+      return excerptId;
+    },
+
+    hasFile(filePath: string): boolean {
+      return fileMap.has(filePath);
+    },
+
+    getExcerptForFile(filePath: string): OpenedFileInfo | null {
+      return fileMap.get(filePath) ?? null;
+    },
+
+    closeFile(filePath: string): void {
+      const info = fileMap.get(filePath);
+      if (!info) return;
+      // removeExcerpt will trigger excerptRemoved event, which cleans up our maps
+      multiBuffer.removeExcerpt(info.excerptId);
+    },
+
+    get files(): ReadonlyMap<string, OpenedFileInfo> {
+      return fileMap;
+    },
+
+    destroy(): void {
+      multiBuffer.off("excerptRemoved", onExcerptRemoved);
+      fileMap.clear();
+      excerptToFile.clear();
+    },
+  };
+}

--- a/src/multibuffer/index.ts
+++ b/src/multibuffer/index.ts
@@ -14,6 +14,8 @@ export {
   resolveAnchorRange,
   reverseSelection,
 } from "./anchor.ts";
+export type { FileNavigator, FileNavigatorOptions, OpenedFileInfo } from "./file-navigator.ts";
+export { createFileNavigator } from "./file-navigator.ts";
 export { createMultiBuffer } from "./multibuffer.ts";
 export { keysCompare, keysEqual, type SlotKey, SlotMap } from "./slot_map.ts";
 export * from "./types.ts";

--- a/tests/multibuffer/file-navigator.test.ts
+++ b/tests/multibuffer/file-navigator.test.ts
@@ -1,0 +1,291 @@
+/**
+ * FileNavigator tests - written BEFORE implementation (TDD).
+ *
+ * Tests for the file-to-excerpt navigation bridge that maps file paths
+ * to excerpts in a MultiBuffer, creating them on demand.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { createFileNavigator } from "../../src/multibuffer/file-navigator.ts";
+import { createMultiBuffer } from "../../src/multibuffer/multibuffer.ts";
+import {
+  generateText,
+  resetCounters,
+  row,
+} from "../helpers.ts";
+
+beforeEach(() => {
+  resetCounters();
+});
+
+/** In-memory file system for testing. */
+function createMockFs(files: Record<string, string>) {
+  return (path: string): Promise<string> => {
+    const content = files[path];
+    if (content === undefined) {
+      return Promise.reject(new Error(`File not found: ${path}`));
+    }
+    return Promise.resolve(content);
+  };
+}
+
+describe("FileNavigator - openFile", () => {
+  test("opens a file and creates an excerpt", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(10) }),
+    });
+
+    const id = await nav.openFile("/src/foo.ts");
+
+    expect(id).toBeDefined();
+    expect(mb.excerpts.length).toBe(1);
+    expect(mb.excerpts[0]?.metadata?.filePath).toBe("/src/foo.ts");
+  });
+
+  test("returns existing excerpt ID when file already open", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(10) }),
+    });
+
+    const id1 = await nav.openFile("/src/foo.ts");
+    const id2 = await nav.openFile("/src/foo.ts");
+
+    expect(id1).toEqual(id2);
+    expect(mb.excerpts.length).toBe(1);
+  });
+
+  test("opens multiple different files", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({
+        "/src/a.ts": generateText(5),
+        "/src/b.ts": generateText(8),
+      }),
+    });
+
+    const id1 = await nav.openFile("/src/a.ts");
+    const id2 = await nav.openFile("/src/b.ts");
+
+    expect(id1).not.toEqual(id2);
+    expect(mb.excerpts.length).toBe(2);
+  });
+
+  test("throws when file cannot be read", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({}),
+    });
+
+    await expect(nav.openFile("/missing.ts")).rejects.toThrow("File not found");
+  });
+
+  test("creates full-file excerpt by default", async () => {
+    const text = generateText(10);
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": text }),
+    });
+
+    await nav.openFile("/src/foo.ts");
+
+    const excerpt = mb.excerpts[0];
+    expect(excerpt).toBeDefined();
+    // Context range should cover full file (row 0 to lineCount)
+    expect(excerpt?.range.context.start.row).toBe(row(0));
+  });
+
+  test("stores filePath in excerpt metadata", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(5) }),
+    });
+
+    await nav.openFile("/src/foo.ts");
+
+    expect(mb.excerpts[0]?.metadata?.filePath).toBe("/src/foo.ts");
+  });
+});
+
+describe("FileNavigator - hasFile", () => {
+  test("returns false for unopened file", () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({}),
+    });
+
+    expect(nav.hasFile("/src/foo.ts")).toBe(false);
+  });
+
+  test("returns true for opened file", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(5) }),
+    });
+
+    await nav.openFile("/src/foo.ts");
+
+    expect(nav.hasFile("/src/foo.ts")).toBe(true);
+  });
+
+  test("returns false after file is closed", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(5) }),
+    });
+
+    await nav.openFile("/src/foo.ts");
+    nav.closeFile("/src/foo.ts");
+
+    expect(nav.hasFile("/src/foo.ts")).toBe(false);
+  });
+});
+
+describe("FileNavigator - getExcerptForFile", () => {
+  test("returns null for unopened file", () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({}),
+    });
+
+    expect(nav.getExcerptForFile("/src/foo.ts")).toBeNull();
+  });
+
+  test("returns info for opened file", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(5) }),
+    });
+
+    const id = await nav.openFile("/src/foo.ts");
+
+    const info = nav.getExcerptForFile("/src/foo.ts");
+    expect(info).not.toBeNull();
+    expect(info?.excerptId).toEqual(id);
+    expect(info?.filePath).toBe("/src/foo.ts");
+  });
+});
+
+describe("FileNavigator - closeFile", () => {
+  test("removes excerpt from multibuffer", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(5) }),
+    });
+
+    await nav.openFile("/src/foo.ts");
+    expect(mb.excerpts.length).toBe(1);
+
+    nav.closeFile("/src/foo.ts");
+    expect(mb.excerpts.length).toBe(0);
+  });
+
+  test("no-op for unopened file", () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({}),
+    });
+
+    // Should not throw
+    expect(() => nav.closeFile("/src/foo.ts")).not.toThrow();
+  });
+
+  test("allows re-opening after close", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(5) }),
+    });
+
+    const id1 = await nav.openFile("/src/foo.ts");
+    nav.closeFile("/src/foo.ts");
+
+    const id2 = await nav.openFile("/src/foo.ts");
+    // New excerpt should be created (different ID)
+    expect(id2).not.toEqual(id1);
+    expect(mb.excerpts.length).toBe(1);
+  });
+});
+
+describe("FileNavigator - files", () => {
+  test("starts empty", () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({}),
+    });
+
+    expect(nav.files.size).toBe(0);
+  });
+
+  test("tracks opened files", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({
+        "/src/a.ts": generateText(3),
+        "/src/b.ts": generateText(4),
+      }),
+    });
+
+    await nav.openFile("/src/a.ts");
+    await nav.openFile("/src/b.ts");
+
+    expect(nav.files.size).toBe(2);
+    expect(nav.files.has("/src/a.ts")).toBe(true);
+    expect(nav.files.has("/src/b.ts")).toBe(true);
+  });
+});
+
+describe("FileNavigator - external excerpt removal sync", () => {
+  test("syncs when excerpt is removed externally via removeExcerpt", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(5) }),
+    });
+
+    const id = await nav.openFile("/src/foo.ts");
+
+    // Remove excerpt externally (not through navigator)
+    mb.removeExcerpt(id);
+
+    expect(nav.hasFile("/src/foo.ts")).toBe(false);
+    expect(nav.files.size).toBe(0);
+  });
+
+  test("syncs when excerpts are cleared externally", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({
+        "/src/a.ts": generateText(3),
+        "/src/b.ts": generateText(4),
+      }),
+    });
+
+    await nav.openFile("/src/a.ts");
+    await nav.openFile("/src/b.ts");
+
+    mb.clearExcerpts();
+
+    expect(nav.hasFile("/src/a.ts")).toBe(false);
+    expect(nav.hasFile("/src/b.ts")).toBe(false);
+    expect(nav.files.size).toBe(0);
+  });
+});
+
+describe("FileNavigator - destroy", () => {
+  test("cleans up event listeners and state", async () => {
+    const mb = createMultiBuffer();
+    const nav = createFileNavigator(mb, {
+      readFile: createMockFs({ "/src/foo.ts": generateText(5) }),
+    });
+
+    await nav.openFile("/src/foo.ts");
+    nav.destroy();
+
+    // After destroy, files map should be empty
+    expect(nav.files.size).toBe(0);
+
+    // Removing excerpts externally should not cause errors
+    // (listener was unregistered)
+    expect(() => mb.clearExcerpts()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `createFileNavigator(multiBuffer, { readFile })` — a standalone factory that bridges file paths to excerpts in a MultiBuffer
- Creates buffers and full-file excerpts on demand via an async `readFile` callback (platform-agnostic: works with Bun, Node, browser, or in-memory)
- Tracks open files via `Map<filePath, OpenedFileInfo>` and stays in sync with external excerpt removal via `excerptRemoved` events
- Stores `filePath` in `ExcerptMetadata` for consumers that inspect `mb.excerpts`

## API
```ts
import { createFileNavigator } from "multibuffer/multibuffer";

const nav = createFileNavigator(multiBuffer, {
  readFile: (path) => Bun.file(path).text(),
});

const id = await nav.openFile("/src/main.ts");  // creates excerpt if needed
await nav.openFile("/src/main.ts");              // returns existing ID
nav.hasFile("/src/main.ts");                     // true
nav.getExcerptForFile("/src/main.ts");           // { filePath, excerptId, bufferId }
nav.closeFile("/src/main.ts");                   // removes excerpt
nav.files;                                       // ReadonlyMap<string, OpenedFileInfo>
nav.destroy();                                   // cleanup listeners
```

## Test plan
- [x] 19 tests covering all methods and edge cases
- [x] External excerpt removal sync (removeExcerpt, clearExcerpts)
- [x] Re-open after close creates new excerpt
- [x] Error propagation when readFile fails
- [x] Destroy cleans up listeners and state
- [x] TypeScript strict mode passes
- [x] Biome lint passes
- [x] Full test suite (2293 tests) passes

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)