### PR TITLE
feat(multibuffer): add editBatch() for cross-excerpt edits

### DIFF
--- a/src/multibuffer/multibuffer.ts
+++ b/src/multibuffer/multibuffer.ts
@@ -13,6 +13,7 @@ import type {
   Anchor,
   Bias,
   Buffer,
+  BufferOffset,
   BufferPoint,
   BufferRow,
   BufferSnapshot,
@@ -26,6 +27,7 @@ import type {
   ExcerptRange,
   ExcerptSpec,
   MultiBuffer,
+  MultiBufferEdit,
   MultiBufferEventMap,
   MultiBufferPoint,
   MultiBufferRow,
@@ -1070,6 +1072,75 @@ class MultiBufferImpl implements MultiBuffer {
 
     // Refresh all excerpts from this buffer with new snapshots
     this._refreshExcerptsForBuffer(buffer, editRow, lineDelta);
+  }
+
+  editBatch(edits: readonly MultiBufferEdit[]): void {
+    if (edits.length === 0) return;
+    const snap = this.snapshot();
+
+    // Resolved edit: buffer-level offsets + which buffer to apply to.
+    interface ResolvedEdit {
+      startOffset: BufferOffset;
+      endOffset: BufferOffset;
+      text: string;
+    }
+
+    // Group resolved edits by buffer ID. All offsets are resolved from the
+    // pre-batch snapshot so that edits don't interfere with each other's positions.
+    const byBuffer = new Map<string, ResolvedEdit[]>();
+
+    for (const { start, end, text } of edits) {
+      const startBuf = snap.toBufferPoint(start);
+      if (!startBuf) continue;
+
+      const endBuf =
+        start.row === end.row && start.column === end.column
+          ? startBuf
+          : snap.toBufferPoint(end);
+      if (!endBuf) continue;
+
+      // biome-ignore lint/plugin/no-type-assertion: expect: BufferId is branded string
+      const bid = startBuf.excerpt.bufferId as string;
+      // biome-ignore lint/plugin/no-type-assertion: expect: BufferId is branded string
+      if ((endBuf.excerpt.bufferId as string) !== bid) continue;
+
+      const buffer = this._buffers.get(bid);
+      if (!buffer) continue;
+
+      const bufSnap = buffer.snapshot();
+      const startOffset = bufSnap.pointToOffset(startBuf.point);
+      const endOffset = bufSnap.pointToOffset(endBuf.point);
+
+      let group = byBuffer.get(bid);
+      if (!group) {
+        group = [];
+        byBuffer.set(bid, group);
+      }
+      group.push({ startOffset, endOffset, text });
+    }
+
+    // Apply each buffer's edits in reverse offset order to preserve positions.
+    for (const [bid, bufEdits] of byBuffer) {
+      const buffer = this._buffers.get(bid);
+      if (!buffer) continue;
+
+      bufEdits.sort((a, b) => {
+        // biome-ignore lint/plugin/no-type-assertion: expect: branded arithmetic for offset comparison
+        return (b.startOffset as number) - (a.startOffset as number);
+      });
+
+      for (const { startOffset, endOffset, text } of bufEdits) {
+        if (text.length === 0) {
+          buffer.delete(startOffset, endOffset);
+        } else if (startOffset === endOffset) {
+          buffer.insert(startOffset, text);
+        } else {
+          buffer.replace(startOffset, endOffset, text);
+        }
+      }
+
+      this._refreshExcerptsForBuffer(buffer);
+    }
   }
 
   updateExcerptMetadata(

--- a/src/multibuffer/types.ts
+++ b/src/multibuffer/types.ts
@@ -221,6 +221,16 @@ export interface ExcerptSpec {
 }
 
 /**
+ * A single edit operation for use with editBatch().
+ * Each edit applies to a single buffer; start and end must resolve to the same buffer.
+ */
+export interface MultiBufferEdit {
+  readonly start: MultiBufferPoint;
+  readonly end: MultiBufferPoint;
+  readonly text: string;
+}
+
+/**
  * A multibuffer presents multiple excerpts from one or more buffers
  * as a single unified scrollable view.
  */
@@ -267,6 +277,18 @@ export interface MultiBuffer {
   moveExcerpt(id: ExcerptId, insertBefore: ExcerptId | undefined): void;
   createAnchor(point: MultiBufferPoint, bias: import("../buffer/types.ts").Bias): Anchor | undefined;
   edit(start: MultiBufferPoint, end: MultiBufferPoint, text: string): void;
+  /**
+   * Apply multiple edits, grouped by buffer, with a single cache rebuild per buffer.
+   *
+   * Each edit must have start and end in the same buffer (cross-buffer single edits are skipped).
+   * Edits to the same buffer are applied in reverse offset order so that earlier edits
+   * don't shift the positions of later ones.
+   * All offsets are resolved from the state before any edits in this batch.
+   *
+   * This enables atomic-looking multi-excerpt, cross-excerpt, and multi-buffer edits —
+   * unlocking the agent workflows blocked by the single-edit limitation.
+   */
+  editBatch(edits: readonly MultiBufferEdit[]): void;
   /**
    * Update the metadata for an excerpt by shallow-merging a patch.
    * No-op if the excerpt doesn't exist.

--- a/tests/multibuffer/multibuffer.test.ts
+++ b/tests/multibuffer/multibuffer.test.ts
@@ -1542,3 +1542,138 @@ describe("moveExcerpt", () => {
     expect(mb.lineCount).toBe(totalBefore);
   });
 });
+
+
+describe("MultiBuffer - editBatch", () => {
+  test("empty batch is a no-op", () => {
+    const buf = createBuffer(createBufferId(), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 2));
+    const v0 = mb.snapshot().version;
+
+    mb.editBatch([]);
+
+    expect(mb.snapshot().version).toBe(v0);
+    expect(mb.snapshot().lines(mbRow(0), mbRow(2))).toEqual(["hello", "world"]);
+  });
+
+  test("single edit in batch behaves like edit()", () => {
+    const buf = createBuffer(createBufferId(), "hello\nworld");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 2));
+
+    mb.editBatch([{ start: mbPoint(0, 0), end: mbPoint(0, 5), text: "goodbye" }]);
+
+    expect(mb.snapshot().lines(mbRow(0), mbRow(2))).toEqual(["goodbye", "world"]);
+  });
+
+  test("two edits to different lines in the same buffer apply both", () => {
+    const buf = createBuffer(createBufferId(), "aaa\nbbb\nccc");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 3));
+
+    mb.editBatch([
+      { start: mbPoint(0, 0), end: mbPoint(0, 3), text: "AAA" },
+      { start: mbPoint(2, 0), end: mbPoint(2, 3), text: "CCC" },
+    ]);
+
+    const lines = mb.snapshot().lines(mbRow(0), mbRow(3));
+    expect(lines[0]).toBe("AAA");
+    expect(lines[1]).toBe("bbb");
+    expect(lines[2]).toBe("CCC");
+  });
+
+  test("two edits to separate excerpts of the same buffer apply both", () => {
+    // Buffer: 6 lines. Two excerpts: rows 0-2 and rows 3-6.
+    const buf = createBuffer(createBufferId(), "a\nb\nc\nd\ne\nf");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 3)); // MB rows 0-2
+    mb.addExcerpt(buf, excerptRange(3, 6)); // MB rows 3-5
+
+    mb.editBatch([
+      { start: mbPoint(0, 0), end: mbPoint(0, 1), text: "X" },
+      { start: mbPoint(3, 0), end: mbPoint(3, 1), text: "Y" },
+    ]);
+
+    const snap = mb.snapshot();
+    expect(snap.lines(mbRow(0), mbRow(1))[0]).toBe("X");
+    expect(snap.lines(mbRow(3), mbRow(4))[0]).toBe("Y");
+  });
+
+  test("edits to two different buffers both apply", () => {
+    const buf1 = createBuffer(createBufferId(), "hello");
+    const buf2 = createBuffer(createBufferId(), "world");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf1, excerptRange(0, 1)); // MB row 0
+    mb.addExcerpt(buf2, excerptRange(0, 1)); // MB row 1
+
+    mb.editBatch([
+      { start: mbPoint(0, 0), end: mbPoint(0, 5), text: "HELLO" },
+      { start: mbPoint(1, 0), end: mbPoint(1, 5), text: "WORLD" },
+    ]);
+
+    const snap = mb.snapshot();
+    expect(snap.lines(mbRow(0), mbRow(1))[0]).toBe("HELLO");
+    expect(snap.lines(mbRow(1), mbRow(2))[0]).toBe("WORLD");
+  });
+
+  test("overlapping offsets within same buffer applied in reverse order", () => {
+    // "abcde" — delete "bc" (1-3) and delete "de" (3-5); reverse order prevents shift errors.
+    const buf = createBuffer(createBufferId(), "abcde");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 1));
+
+    mb.editBatch([
+      { start: mbPoint(0, 1), end: mbPoint(0, 3), text: "" }, // delete "bc"
+      { start: mbPoint(0, 3), end: mbPoint(0, 5), text: "" }, // delete "de"
+    ]);
+
+    expect(mb.snapshot().lines(mbRow(0), mbRow(1))[0]).toBe("a");
+  });
+
+  test("editBatch with cross-buffer edits skips cross-buffer single edit", () => {
+    // An edit whose start and end are in different buffers is skipped.
+    const buf1 = createBuffer(createBufferId(), "hello");
+    const buf2 = createBuffer(createBufferId(), "world");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf1, excerptRange(0, 1)); // MB row 0
+    mb.addExcerpt(buf2, excerptRange(0, 1)); // MB row 1
+
+    // This edit spans from buf1 to buf2 — should be skipped (not crash).
+    mb.editBatch([
+      { start: mbPoint(0, 0), end: mbPoint(1, 5), text: "X" },
+    ]);
+
+    // Neither buffer should have changed.
+    const snap = mb.snapshot();
+    expect(snap.lines(mbRow(0), mbRow(1))[0]).toBe("hello");
+    expect(snap.lines(mbRow(1), mbRow(2))[0]).toBe("world");
+  });
+
+  test("editBatch increments version when changes are made", () => {
+    const buf = createBuffer(createBufferId(), "abc");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 1));
+    const v0 = mb.snapshot().version;
+
+    mb.editBatch([{ start: mbPoint(0, 0), end: mbPoint(0, 1), text: "X" }]);
+
+    expect(mb.snapshot().version).toBeGreaterThan(v0);
+  });
+
+  test("editBatch: insert in one excerpt, delete in another, same buffer", () => {
+    const buf = createBuffer(createBufferId(), "foo\nbar\nbaz");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buf, excerptRange(0, 2)); // MB rows 0-1: "foo", "bar"
+    mb.addExcerpt(buf, excerptRange(2, 3)); // MB row 2: "baz"
+
+    mb.editBatch([
+      { start: mbPoint(0, 3), end: mbPoint(0, 3), text: "!" }, // insert "!" at end of "foo"
+      { start: mbPoint(2, 0), end: mbPoint(2, 3), text: "qux" }, // replace "baz" with "qux"
+    ]);
+
+    const snap = mb.snapshot();
+    expect(snap.lines(mbRow(0), mbRow(1))[0]).toBe("foo!");
+    expect(snap.lines(mbRow(2), mbRow(3))[0]).toBe("qux");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `editBatch(edits: readonly MultiBufferEdit[])` method to the `MultiBuffer` interface, enabling atomic multi-excerpt and multi-buffer edits
- All edit offsets are resolved from a pre-batch snapshot so edits don't shift each other's positions; edits are grouped by buffer and applied in reverse offset order with a single cache rebuild per buffer
- Includes 9 new tests covering empty batch, single edit, same-buffer multi-line, cross-excerpt same buffer, multi-buffer, offset stability, cross-buffer skip, version increment, and mixed insert/replace scenarios

Closes #157

## Test plan

- [x] All 2274 existing tests pass
- [x] 9 new `editBatch` tests pass
- [x] TypeScript typecheck passes
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)