### PR TITLE
perf(highlighter): add InjectionHighlighter benchmarks and remove dead parameter

### DIFF
--- a/benchmarks/index.ts
+++ b/benchmarks/index.ts
@@ -16,6 +16,7 @@ import { diffControllerBenchmarks } from "./diff-controller.bench.ts";
 import { editorBenchmarks } from "./editor.bench.ts";
 import { type BenchmarkSuite, runBenchmarks } from "./harness.ts";
 import { highlighterBenchmarks } from "./highlighter.bench.ts";
+import { injectionHighlighterBenchmarks } from "./injection-highlighter.bench.ts";
 import { multibufferBenchmarks } from "./multibuffer.bench.ts";
 import { rendererBenchmarks } from "./renderer.bench.ts";
 import { tileMapBenchmarks } from "./tile-map.bench.ts";
@@ -35,6 +36,7 @@ const suites: BenchmarkSuite[] = [
   diffBenchmarks,
   diffControllerBenchmarks,
   highlighterBenchmarks,
+  injectionHighlighterBenchmarks,
 ];
 
 if (!jsonMode) {

--- a/benchmarks/injection-highlighter.bench.ts
+++ b/benchmarks/injection-highlighter.bench.ts
@@ -1,0 +1,160 @@
+/**
+ * InjectionHighlighter benchmarks.
+ *
+ * Measures tree-sitter parse + injection performance for markdown documents
+ * containing YAML frontmatter and fenced code blocks with embedded languages.
+ *
+ * Uses async `setup` to load tree-sitter WASM (same paths as the test suite).
+ */
+
+import * as path from "node:path";
+import { InjectionHighlighter } from "../src/renderer/injection-highlighter.ts";
+import { markdownQuery } from "../src/renderer/queries/index.ts";
+import type { BenchmarkSuite } from "./harness.ts";
+
+const WASM_DIR = path.join(import.meta.dir, "../playground/wasm");
+
+/** Markdown with YAML frontmatter (~20 lines). */
+function generateMarkdownWithFrontmatter(bodyLines: number): string {
+  const frontmatter = [
+    "---",
+    "title: Benchmark Document",
+    "author: Performance Suite",
+    "date: 2026-03-26",
+    "tags:",
+    "  - benchmark",
+    "  - performance",
+    "  - injection-highlighter",
+    "enabled: true",
+    "count: 42",
+    "---",
+  ].join("\n");
+
+  const body = Array.from(
+    { length: bodyLines },
+    (_, i) => `This is paragraph ${i} with **bold** and *italic* text and a [link](http://example.com).`,
+  ).join("\n\n");
+
+  return `${frontmatter}\n\n${body}`;
+}
+
+/** Markdown with multiple fenced TypeScript code blocks. */
+function generateMarkdownWithCodeBlocks(blockCount: number): string {
+  const sections = Array.from({ length: blockCount }, (_, i) => {
+    const codeLines = Array.from(
+      { length: 10 },
+      (_, j) => `const var${i}_${j}: number = ${i * 10 + j};`,
+    ).join("\n");
+    return `## Section ${i}\n\nSome text before code block ${i}.\n\n\`\`\`typescript\n${codeLines}\n\`\`\`\n`;
+  });
+  return sections.join("\n");
+}
+
+const markdownFrontmatter500 = generateMarkdownWithFrontmatter(500);
+const markdownFrontmatter2k = generateMarkdownWithFrontmatter(2000);
+const markdownCodeBlocks20 = generateMarkdownWithCodeBlocks(20);
+
+// Shared highlighter initialized by the first benchmark's setup
+let highlighter: InjectionHighlighter;
+
+export const injectionHighlighterBenchmarks: BenchmarkSuite = {
+  name: "InjectionHighlighter Operations",
+  benchmarks: [
+    // ── Full parse with YAML frontmatter (500 body lines) ─────────
+    {
+      name: "Full parse - markdown+YAML frontmatter (500 body lines)",
+      iterations: 50,
+      targetMs: 30,
+      setup: async () => {
+        highlighter = new InjectionHighlighter(markdownQuery);
+        await highlighter.init(
+          path.join(WASM_DIR, "tree-sitter.wasm"),
+          path.join(WASM_DIR, "tree-sitter-markdown.wasm"),
+          "markdown",
+        );
+        await highlighter.loadLanguage(
+          "yaml",
+          path.join(WASM_DIR, "tree-sitter-yaml.wasm"),
+        );
+        await highlighter.loadLanguage(
+          "typescript",
+          path.join(WASM_DIR, "tree-sitter-typescript.wasm"),
+        );
+      },
+      fn: () => {
+        highlighter.parseBuffer(
+          `full-fm-500-${Math.random()}`,
+          markdownFrontmatter500,
+        );
+      },
+    },
+
+    // ── Full parse with YAML frontmatter (2K body lines) ──────────
+    {
+      name: "Full parse - markdown+YAML frontmatter (2K body lines)",
+      iterations: 20,
+      targetMs: 100,
+      fn: () => {
+        highlighter.parseBuffer(
+          `full-fm-2k-${Math.random()}`,
+          markdownFrontmatter2k,
+        );
+      },
+    },
+
+    // ── Full parse with 20 fenced code blocks ─────────────────────
+    {
+      name: "Full parse - markdown with 20 fenced code blocks",
+      iterations: 50,
+      targetMs: 30,
+      fn: () => {
+        highlighter.parseBuffer(
+          `full-cb-20-${Math.random()}`,
+          markdownCodeBlocks20,
+        );
+      },
+    },
+
+    // ── getLineTokens on YAML frontmatter row ─────────────────────
+    {
+      name: "getLineTokens - YAML frontmatter row (injection path)",
+      iterations: 10_000,
+      targetMs: 1,
+      setup: () => {
+        highlighter.parseBuffer("tokens-fm", markdownFrontmatter500);
+      },
+      fn: () => {
+        // Row 3 is inside YAML frontmatter (e.g., "date: 2026-03-26")
+        highlighter.getLineTokens("tokens-fm", 3);
+      },
+    },
+
+    // ── getLineTokens on primary markdown row (skip injection) ────
+    {
+      name: "getLineTokens - markdown body row (injection-skip path)",
+      iterations: 10_000,
+      targetMs: 1,
+      setup: () => {
+        highlighter.parseBuffer("tokens-body", markdownFrontmatter500);
+      },
+      fn: () => {
+        // Row 20 is well past the frontmatter, in the markdown body
+        highlighter.getLineTokens("tokens-body", 20);
+      },
+    },
+
+    // ── getLineTokens on fenced code block row ────────────────────
+    {
+      name: "getLineTokens - fenced code block row (code injection path)",
+      iterations: 10_000,
+      targetMs: 1,
+      setup: () => {
+        highlighter.parseBuffer("tokens-cb", markdownCodeBlocks20);
+      },
+      fn: () => {
+        // Row 5 is inside the first fenced code block's content
+        highlighter.getLineTokens("tokens-cb", 5);
+      },
+    },
+  ],
+};

--- a/src/renderer/injection-highlighter.ts
+++ b/src/renderer/injection-highlighter.ts
@@ -212,7 +212,6 @@ export class InjectionHighlighter implements SyntaxHighlighter {
         row,
         tokens,
         null,
-        parse.injectionRanges,
       );
     }
 
@@ -375,7 +374,6 @@ export class InjectionHighlighter implements SyntaxHighlighter {
     targetRow: number,
     tokens: Token[],
     inheritedColor: string | null,
-    injectionRanges: InjectionRange[],
   ): void {
     if (
       node.endPosition.row < targetRow ||
@@ -465,7 +463,6 @@ export class InjectionHighlighter implements SyntaxHighlighter {
           targetRow,
           tokens,
           colorToPropagate,
-          injectionRanges,
         );
       }
     }


### PR DESCRIPTION
## Summary

- **Adds benchmark suite for `InjectionHighlighter`** (backlog item #4 from #325) — covers `parseBuffer()` and `getLineTokens()` across markdown+YAML frontmatter and fenced code block scenarios. Six benchmarks total:
  - Full parse: markdown+YAML frontmatter (500 and 2K body lines)
  - Full parse: markdown with 20 fenced TypeScript code blocks
  - `getLineTokens`: YAML frontmatter row (injection path)
  - `getLineTokens`: markdown body row (injection-skip path)
  - `getLineTokens`: fenced code block row (code injection path)
- **Removes dead `injectionRanges` parameter** from `_collectTokensWithInjectionSkip()` (backlog item #5 from #325) — the parameter was passed through all recursive calls but never accessed; injection skipping is fully handled by node-type checks

## Benchmark baselines (measured locally)

| Benchmark | Avg | p95 |
|---|---|---|
| Full parse - markdown+YAML (500 lines) | 11.1ms | 11.4ms |
| Full parse - markdown+YAML (2K lines) | 44.8ms | 46.2ms |
| Full parse - 20 fenced code blocks | 2.7ms | 2.9ms |
| getLineTokens - YAML row | 6.5µs | 7.7µs |
| getLineTokens - markdown body row | 0.13ms | 0.18ms |
| getLineTokens - fenced code block row | <1ms | <1ms |

## Test plan

- [x] All 2265 existing tests pass (`bun test`)
- [x] All new benchmarks pass within targets (`bun run bench`)
- [x] TypeScript type checking passes (`bun run typecheck`)
- [x] Linting passes (`bun run lint`)

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)