### PR TITLE
feat(canvas): cursor blink, focus state, and selection rendering

### DIFF
--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -11,7 +11,7 @@
  */
 
 import type { MultiBufferPoint, MultiBufferRow, MultiBufferSnapshot } from "../multibuffer/types.ts";
-import { sliceTokensToRange } from "./dom.ts";
+import { computeSelectionRects, sliceTokensToRange } from "./dom.ts";
 import type { SyntaxHighlighter, Token } from "./highlighter.ts";
 import {
   calculateContentHeight,
@@ -207,6 +207,15 @@ export class CanvasRenderer implements Renderer {
   private _charWidth = 8; // Default, will be measured
   private _computedStyle: CSSStyleDeclaration | null = null;
   private _pendingRender: number | null = null;
+  private _focused = false;
+  private _cursorVisible = true;
+  private _blinkIntervalMs: number | false = 600;
+  private _blinkTimer: ReturnType<typeof setInterval> | null = null;
+  /** When true, the cursor is never rendered (for read-only mode). */
+  private _cursorHidden = false;
+  /** Cached render state + lines for blink redraws. */
+  private _lastRenderState: RenderState | null = null;
+  private _lastRenderLines: readonly string[] | null = null;
 
   // Color cache to avoid repeated CSS variable resolution
   private _colorCache = new Map<string, string>();
@@ -314,6 +323,9 @@ export class CanvasRenderer implements Renderer {
   }
 
   unmount(): void {
+    // Stop cursor blink timer
+    this._stopBlink();
+
     // Cancel any pending animation frames
     if (this._wrapBuildFrame !== null && typeof cancelAnimationFrame !== "undefined") {
       cancelAnimationFrame(this._wrapBuildFrame);
@@ -361,6 +373,8 @@ export class CanvasRenderer implements Renderer {
     this._onMouseMove = null;
     this._onMouseUp = null;
     this._onScrollCallback = null;
+    this._lastRenderState = null;
+    this._lastRenderLines = null;
   }
 
   setMeasurements(measurements: Measurements): void {
@@ -557,9 +571,21 @@ export class CanvasRenderer implements Renderer {
     // Render selections
     this._renderSelections(ctx, state);
 
-    // Render cursor if focused
-    if (state.focused && state.selections.length > 0) {
-      this._renderCursor(ctx, state);
+    // Render cursor: blinks when focused, solid when unfocused
+    if (!this._cursorHidden && state.selections.length > 0) {
+      // When focused, respect blink phase; when unfocused, always show solid cursor
+      if (!state.focused || this._cursorVisible) {
+        this._renderCursor(ctx, state);
+      }
+    }
+
+    // Cache state for blink redraws
+    this._lastRenderState = state;
+    this._lastRenderLines = lines;
+
+    // Sync focus state from RenderState
+    if (state.focused !== this._focused) {
+      this._setFocusedInternal(state.focused);
     }
   }
 
@@ -756,53 +782,29 @@ export class CanvasRenderer implements Renderer {
     const lineHeight = this._measurements.lineHeight;
     const charWidth = this._charWidth;
     const gutterWidth = this._getEffectiveGutterWidth();
+    const wrapWidth = this._measurements.wrapWidth ?? 0;
+    const scrollTopOffset = Math.floor(state.viewport.scrollTop / lineHeight) * lineHeight;
 
     ctx.fillStyle = this._resolveColor(this._theme.selection);
 
     for (const sel of state.selections) {
-      // Resolve anchors to get actual positions
       const startPoint = this._snapshot.resolveAnchor(sel.range.start);
       const endPoint = this._snapshot.resolveAnchor(sel.range.end);
-
       if (!startPoint || !endPoint) continue;
 
-      if (startPoint.row === endPoint.row && startPoint.column === endPoint.column) {
-        continue; // Empty selection
-      }
+      const rects = computeSelectionRects(
+        startPoint,
+        endPoint,
+        this._snapshot,
+        lineHeight,
+        charWidth,
+        gutterWidth,
+        wrapWidth,
+        this._wrapMap,
+      );
 
-      // Normalize selection direction
-      let startRow = startPoint.row;
-      let startCol = startPoint.column;
-      let endRow = endPoint.row;
-      let endCol = endPoint.column;
-      if (startRow > endRow || (startRow === endRow && startCol > endCol)) {
-        [startRow, startCol, endRow, endCol] = [endRow, endCol, startRow, startCol];
-      }
-
-      // Calculate visual positions relative to viewport
-      for (let row = startRow; row <= endRow; row++) {
-        if (row < state.viewport.startRow || row >= state.viewport.endRow) continue;
-
-        const lineText = this._getLineText(
-          // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction
-          row as MultiBufferRow,
-        );
-        const visualRow = this._wrapMap
-          // biome-ignore lint/plugin/no-type-assertion: expect: branded type construction
-          ? this._wrapMap.bufferRowToFirstVisualRow(row as MultiBufferRow)
-          : row;
-        const screenY = (visualRow - Math.floor(state.viewport.scrollTop / lineHeight)) * lineHeight;
-
-        const isFirstRow = row === startRow;
-        const isLastRow = row === endRow;
-
-        const selStartCol = isFirstRow ? startCol : 0;
-        const selEndCol = isLastRow ? endCol : lineText.length;
-
-        const startX = gutterWidth + charColToVisualCol(lineText.slice(0, selStartCol), selStartCol) * charWidth;
-        const endX = gutterWidth + charColToVisualCol(lineText.slice(0, selEndCol), selEndCol) * charWidth;
-
-        ctx.fillRect(startX, screenY, endX - startX, lineHeight);
+      for (const rect of rects) {
+        ctx.fillRect(rect.x, rect.y - scrollTopOffset, rect.width, rect.height);
       }
     }
   }
@@ -969,6 +971,38 @@ export class CanvasRenderer implements Renderer {
     this._onScrollCallback = cb;
   }
 
+  /** Update focus state — call when the editor gains or loses keyboard focus. */
+  setFocused(focused: boolean): void {
+    this._setFocusedInternal(focused);
+  }
+
+  /**
+   * Configure cursor blink behavior.
+   * @param ms - Blink interval in milliseconds (must be > 0), or `false` to disable blinking
+   *             (steady cursor). Default is 600ms.
+   * @throws {RangeError} If `ms` is a number that is not positive.
+   */
+  setCursorBlink(ms: number | false): void {
+    if (typeof ms === "number" && ms <= 0) {
+      throw new RangeError(`setCursorBlink: interval must be > 0, got ${ms}`);
+    }
+    this._blinkIntervalMs = ms;
+    this._restartBlink();
+  }
+
+  /**
+   * Set whether the cursor should be hidden.
+   * When true, the cursor is never rendered (for read-only mode).
+   */
+  setCursorHidden(hidden: boolean): void {
+    this._cursorHidden = hidden;
+    if (hidden) {
+      this._stopBlink();
+    } else if (this._focused) {
+      this._restartBlink();
+    }
+  }
+
   /**
    * Render the cursor at a given position.
    */
@@ -989,6 +1023,55 @@ export class CanvasRenderer implements Renderer {
   }
 
   // --- Private Methods ---
+
+  /**
+   * Internal focus state update. Starts or stops the blink timer.
+   * Called from both `setFocused()` and `render()` (to sync with RenderState).
+   */
+  private _setFocusedInternal(focused: boolean): void {
+    this._focused = focused;
+    if (focused) {
+      this._restartBlink();
+    } else {
+      this._stopBlink();
+      this._cursorVisible = true; // solid cursor when unfocused
+    }
+  }
+
+  /**
+   * Unconditionally stop and restart the cursor blink interval.
+   * Resets visibility to true so the cursor is immediately shown.
+   */
+  private _restartBlink(): void {
+    this._stopBlink();
+    this._cursorVisible = true;
+
+    if (this._blinkIntervalMs === false || !this._focused || this._cursorHidden) {
+      return;
+    }
+
+    this._blinkTimer = setInterval(() => {
+      this._cursorVisible = !this._cursorVisible;
+      this._blinkRedraw();
+    }, this._blinkIntervalMs);
+  }
+
+  /** Stop the cursor blink timer. */
+  private _stopBlink(): void {
+    if (this._blinkTimer !== null) {
+      clearInterval(this._blinkTimer);
+      this._blinkTimer = null;
+    }
+  }
+
+  /**
+   * Re-render using cached state to update cursor visibility.
+   * Avoids requiring the caller to pass state on every blink tick.
+   */
+  private _blinkRedraw(): void {
+    if (!this._lastRenderState || !this._lastRenderLines) return;
+    this.render(this._lastRenderState, this._lastRenderLines);
+  }
 
   private _measureCharWidth(container: HTMLElement): number {
     if (this._measurements.charWidth) {

--- a/tests/renderer/canvas.test.ts
+++ b/tests/renderer/canvas.test.ts
@@ -797,3 +797,123 @@ describe("canvas renderer exports", () => {
     expect(typeof CanvasRenderer).toBe("function");
   });
 });
+
+describe("CanvasRenderer cursor blink and focus", () => {
+  test("setCursorBlink throws on non-positive interval", () => {
+    const { CanvasRenderer } = require("../../src/renderer/canvas.ts");
+    const renderer = new CanvasRenderer({ lineHeight: 20, charWidth: 8, gutterWidth: 40 });
+    expect(() => renderer.setCursorBlink(0)).toThrow(RangeError);
+    expect(() => renderer.setCursorBlink(-100)).toThrow(RangeError);
+  });
+
+  test("setCursorBlink accepts positive number", () => {
+    const { CanvasRenderer } = require("../../src/renderer/canvas.ts");
+    const renderer = new CanvasRenderer({ lineHeight: 20, charWidth: 8, gutterWidth: 40 });
+    expect(() => renderer.setCursorBlink(500)).not.toThrow();
+  });
+
+  test("setCursorBlink accepts false to disable blinking", () => {
+    const { CanvasRenderer } = require("../../src/renderer/canvas.ts");
+    const renderer = new CanvasRenderer({ lineHeight: 20, charWidth: 8, gutterWidth: 40 });
+    expect(() => renderer.setCursorBlink(false)).not.toThrow();
+  });
+
+  test("setFocused does not throw", () => {
+    const { CanvasRenderer } = require("../../src/renderer/canvas.ts");
+    const renderer = new CanvasRenderer({ lineHeight: 20, charWidth: 8, gutterWidth: 40 });
+    expect(() => renderer.setFocused(true)).not.toThrow();
+    expect(() => renderer.setFocused(false)).not.toThrow();
+  });
+
+  test("setCursorHidden does not throw", () => {
+    const { CanvasRenderer } = require("../../src/renderer/canvas.ts");
+    const renderer = new CanvasRenderer({ lineHeight: 20, charWidth: 8, gutterWidth: 40 });
+    expect(() => renderer.setCursorHidden(true)).not.toThrow();
+    expect(() => renderer.setCursorHidden(false)).not.toThrow();
+  });
+});
+
+describe("computeSelectionRects integration", () => {
+  test("computeSelectionRects is importable from dom.ts", () => {
+    const { computeSelectionRects } = require("../../src/renderer/dom.ts");
+    expect(typeof computeSelectionRects).toBe("function");
+  });
+
+  test("empty selection produces no rects", () => {
+    const { computeSelectionRects } = require("../../src/renderer/dom.ts");
+    const start = { row: row(0), column: 0 };
+    const end = { row: row(0), column: 0 };
+
+    const bufferId = createBufferId();
+    const buffer = createBuffer(bufferId, "hello world");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buffer, excerptRange(0, 1));
+    const snapshot = mb.snapshot();
+
+    const rects = computeSelectionRects(start, end, snapshot, 20, 8, 40, 0, null);
+    expect(rects).toEqual([]);
+  });
+
+  test("single-line selection produces one rect", () => {
+    const { computeSelectionRects } = require("../../src/renderer/dom.ts");
+
+    const bufferId = createBufferId();
+    const buffer = createBuffer(bufferId, "hello world");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buffer, excerptRange(0, 1));
+    const snapshot = mb.snapshot();
+
+    const start = { row: row(0), column: 2 };
+    const end = { row: row(0), column: 7 };
+    const rects = computeSelectionRects(start, end, snapshot, 20, 8, 40, 0, null);
+    expect(rects.length).toBe(1);
+    expect(rects[0].x).toBe(40 + 2 * 8); // gutterWidth + startCol * charWidth
+    expect(rects[0].y).toBe(0);
+    expect(rects[0].width).toBe(5 * 8); // (7-2) * charWidth
+    expect(rects[0].height).toBe(20);
+  });
+
+  test("multi-line selection produces one rect per line", () => {
+    const { computeSelectionRects } = require("../../src/renderer/dom.ts");
+
+    const bufferId = createBufferId();
+    const buffer = createBuffer(bufferId, "hello\nworld\nfoo");
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buffer, excerptRange(0, 3));
+    const snapshot = mb.snapshot();
+
+    const start = { row: row(0), column: 2 };
+    const end = { row: row(2), column: 1 };
+    const rects = computeSelectionRects(start, end, snapshot, 20, 8, 40, 0, null);
+    expect(rects.length).toBe(3);
+    // Row 0: from col 2 to end of line (5 chars + 0.3 overshoot)
+    expect(rects[0].y).toBe(0);
+    // Row 1: full line
+    expect(rects[1].y).toBe(20);
+    // Row 2: from col 0 to col 1
+    expect(rects[2].y).toBe(40);
+    expect(rects[2].x).toBe(40); // gutterWidth + 0
+    expect(rects[2].width).toBe(8); // 1 * charWidth
+  });
+
+  test("selection with soft wrapping produces rects per visual segment", () => {
+    const { computeSelectionRects } = require("../../src/renderer/dom.ts");
+    const { WrapMap } = require("../../src/renderer/wrap-map.ts");
+
+    const bufferId = createBufferId();
+    const buffer = createBuffer(bufferId, "abcdefghijklmnopqrst"); // 20 chars
+    const mb = createMultiBuffer();
+    mb.addExcerpt(buffer, excerptRange(0, 1));
+    const snapshot = mb.snapshot();
+
+    const wrapMap = new WrapMap(snapshot, 10); // wrap at 10 cols
+
+    const start = { row: row(0), column: 5 };
+    const end = { row: row(0), column: 15 };
+    const rects = computeSelectionRects(start, end, snapshot, 20, 8, 40, 10, wrapMap);
+    // Should have 2 rects: one for segment 0 (cols 5-9) and one for segment 1 (cols 10-14)
+    expect(rects.length).toBe(2);
+    expect(rects[0].y).toBe(0); // first visual row
+    expect(rects[1].y).toBe(20); // second visual row (wrapped)
+  });
+});


### PR DESCRIPTION
## Summary

Adds cursor and selection rendering to the Canvas renderer, completing #282.

- **Cursor blinking**: `setInterval`-based toggle (default 600ms, configurable via `setCursorBlink(ms | false)`). Blinks when focused, solid when unfocused.
- **Focus state**: `setFocused(focused)` with internal `_restartBlink()` helper that unconditionally clears/restarts the interval, avoiding the early-return guard bug from the previous attempt.
- **Selection rendering**: Refactored `_renderSelections()` to reuse the pure `computeSelectionRects()` function from dom.ts, which correctly handles multi-line selections and soft-wrapped content via WrapMap.
- **Cursor hiding**: `setCursorHidden(hidden)` for read-only mode.
- **API alignment**: `setFocused()`, `setCursorBlink()`, and `setCursorHidden()` are methods on `CanvasRenderer` (not the `Renderer` interface), matching how `DomRenderer` exposes these. Focus is also synced from `RenderState.focused` during `render()`.

## Previous review feedback addressed

1. **`setBlinkInterval` bug**: Uses `_restartBlink()` that unconditionally clears and restarts the interval, bypassing any early-return guard.
2. **API inconsistency**: Methods are on the concrete class (not the `Renderer` interface), matching DomRenderer's pattern. Focus also syncs via `RenderState.focused` during render().
3. **Incomplete scope**: Selection rendering is fully implemented using `computeSelectionRects()` with multi-line and soft-wrap support.

## Test plan

- [x] `bun test` — all 2284 tests pass
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — clean
- [x] New tests for `setCursorBlink`, `setFocused`, `setCursorHidden`
- [x] New tests for `computeSelectionRects` integration (empty, single-line, multi-line, soft-wrapped)

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)